### PR TITLE
[Feature #8] 구인게시판 목록 기능 작성

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployPostsController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployPostsController.java
@@ -1,0 +1,67 @@
+package com.bridgeon.app.domain.board.controller;
+
+
+import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
+import com.bridgeon.app.domain.board.service.EmployPostService;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.global.dto.response.PageListResponseDto;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import com.bridgeon.app.global.enums.user.InterestField;
+import com.bridgeon.app.global.enums.user.Region;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.EmployErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/employ-posts")
+@RequiredArgsConstructor
+public class GetEmployPostsController {
+
+    private final EmployPostService employPostService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<Map<String, Object>>> getEmployPosts(
+            @RequestParam(required = false) Region region,
+            @RequestParam(required = false) InterestField employType,
+            @RequestParam(required = false, name = "title") String employTitle,
+//            @AuthenticationPrincipal User user,
+            @RequestAttribute(name = "userId", required = false) Long userId,
+            @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        var pageResult = employPostService.getEmployPosts(
+            region, employType, employTitle, pageable, userId
+        );
+
+        //추후에 인증 구현되면 바꾸기
+//        var resultPage = employPostService.getEmployPosts(region, employType, title, pageable, user.getId());
+        PageListResponseDto<EmployPostItemResponseDto> dto = PageListResponseDto.of(pageResult);
+
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("employPosts", dto.items());
+        data.put("page", dto.page());
+        data.put("size", dto.size());
+        data.put("totalElements", dto.totalElements());
+        data.put("totalPages", dto.totalPages());
+        data.put("hasNext", dto.hasNext());
+        data.put("hasPrev", dto.hasPrev());
+
+        return ResponseEntity.ok(ResponseDto.success(
+                HttpStatus.OK,
+                "OK",
+                data
+            )
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
@@ -1,0 +1,40 @@
+package com.bridgeon.app.domain.board.dto.response;
+
+import com.bridgeon.app.domain.board.entity.EmployBoard;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.global.enums.user.InterestField;
+import com.bridgeon.app.global.enums.user.Region;
+
+import java.time.LocalDateTime;
+
+public record EmployPostItemResponseDto(
+        Long employBoardId,
+        Long userId, // 인증 구현되면 수정 할 예정
+        Region region,
+        InterestField employType,
+        String employTitle,
+        String employContent,
+        LocalDateTime employStartDate,
+        LocalDateTime employEndDate,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt,
+        boolean isScraped
+) {
+    public static EmployPostItemResponseDto of(EmployBoard e, boolean isScraped) {
+        return new EmployPostItemResponseDto(
+                e.getId(),
+                e.getUser() != null ? e.getUser().getId() : null, // 인증 구현되면 수정 예정
+                e.getRegion(),
+                e.getEmployType(),
+                e.getEmployTitle(),
+                e.getEmployContent(),
+                e.getEmployStartDate(),
+                e.getEmployEndDate(),
+                e.getCreatedAt(),
+                e.getUpdatedAt(),
+                e.getDeletedAt(),
+                isScraped
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostListResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostListResponseDto.java
@@ -1,0 +1,11 @@
+package com.bridgeon.app.domain.board.dto.response;
+
+import java.util.List;
+
+public record EmployPostListResponseDto(
+        List<EmployPostItemResponseDto> employPostItemResponseDtoList,
+        int page,
+        int size,
+        long total
+) {
+}

--- a/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployBoardJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployBoardJpaRepository.java
@@ -1,0 +1,8 @@
+package com.bridgeon.app.domain.board.repositroy;
+
+import com.bridgeon.app.domain.board.entity.EmployBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployBoardJpaRepository extends JpaRepository<EmployBoard, Long> {
+
+}

--- a/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployScrapJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployScrapJpaRepository.java
@@ -1,0 +1,8 @@
+package com.bridgeon.app.domain.board.repositroy;
+
+import com.bridgeon.app.domain.board.entity.EmployScrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployScrapJpaRepository extends JpaRepository<EmployScrap, Long> {
+    boolean existsByUserIdAndEmployBoardId(Long userId, Long employBoardId);
+}

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployPostService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployPostService.java
@@ -1,0 +1,81 @@
+package com.bridgeon.app.domain.board.service;
+
+
+import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
+import com.bridgeon.app.domain.board.entity.EmployBoard;
+import com.bridgeon.app.domain.board.repositroy.EmployBoardJpaRepository;
+import com.bridgeon.app.domain.board.repositroy.EmployScrapJpaRepository;
+import com.bridgeon.app.global.enums.user.InterestField;
+import com.bridgeon.app.global.enums.user.Region;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.EmployErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+
+@Service
+@RequiredArgsConstructor
+public class EmployPostService {
+
+    private final EmployBoardJpaRepository employBoardJpaRepository;
+    private final EmployScrapJpaRepository employScrapJpaRepository;
+
+    @Transactional(readOnly = true)
+    public Page<EmployPostItemResponseDto> getEmployPosts(
+            Region region, // 선택값
+            InterestField employType, // 선택값
+            String employTitle,  // 선택값(부분검색)
+            Pageable pageable,
+            Long currentUserId
+    ) {
+        // 페이지 크기 제한 검사
+        if (pageable.getPageSize() > 50) {
+            throw new BusinessException(EmployErrorCode.PAGE_SIZE_TOO_LARGE);
+        }
+
+        // 제목 필수 검사
+        if (employTitle != null && employTitle.isBlank()) {
+            throw new BusinessException(EmployErrorCode.TITLE_REQUIRED);
+        }
+
+        // 제목 정규화
+        final String normalizedTitle = (employTitle == null || employTitle.isBlank()) ? null : employTitle;
+
+        // 기본 정렬 보장
+        final Pageable ensured = pageable.getSort().isSorted()
+                ? pageable
+                : PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // QBE prode 구성, 검색기능
+        EmployBoard probe = EmployBoard.builder()
+                .region(region)
+                .employType(employType)
+                .employTitle(normalizedTitle)
+                .build();
+
+        ExampleMatcher matcher = ExampleMatcher.matching()
+                .withIgnoreNullValues() //prode에서 null인 필드는 조건에서 뺌
+                .withMatcher("employTitle", m -> m.contains().ignoreCase()) //대소문자 무시
+                .withIgnorePaths(
+                        "id", "user",
+                        "employContent",
+                        "employStartDate", "employEndDate",
+                        "createdAt", "updatedAt", "deletedAt"
+                );
+
+        Example<EmployBoard> example = Example.of(probe, matcher);
+
+        Page<EmployBoard> boards = employBoardJpaRepository.findAll(example, ensured);
+
+        // DTO 매핑
+        return boards.map(e -> EmployPostItemResponseDto.of(
+                e,
+                currentUserId != null &&
+                        employScrapJpaRepository.existsByUserIdAndEmployBoardId(currentUserId, e.getId())
+        ));
+    }
+}

--- a/src/main/java/com/bridgeon/app/global/dto/response/PageListResponseDto.java
+++ b/src/main/java/com/bridgeon/app/global/dto/response/PageListResponseDto.java
@@ -1,0 +1,27 @@
+package com.bridgeon.app.global.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageListResponseDto<T>(
+        List<T> items,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext,
+        boolean hasPrev
+) {
+    public static <T> PageListResponseDto<T> of(Page<T> page) {
+        return new PageListResponseDto<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/global/exception/FieldError.java
+++ b/src/main/java/com/bridgeon/app/global/exception/FieldError.java
@@ -36,7 +36,7 @@ public class FieldError {
     public static List<FieldError> of(
             final BindingResult bindingResult
     ) {
-        if (bindingResult == null || bindingResult.hasFieldErrors()) {
+        if (bindingResult == null || !bindingResult.hasFieldErrors()) {
             return new ArrayList<>();
         }
 

--- a/src/main/java/com/bridgeon/app/global/exception/error/EmployErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/EmployErrorCode.java
@@ -1,0 +1,25 @@
+package com.bridgeon.app.global.exception.error;
+
+import com.bridgeon.app.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EmployErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_SEARCH_CONDITION(HttpStatus.BAD_REQUEST.value(), "E4001", "잘못된 검색 조건입니다."),
+    TITLE_REQUIRED(HttpStatus.BAD_REQUEST.value(), "E4002", "제목은 반드시 입력해야 합니다."),
+    PAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST.value(), "E4003", "요청한 페이지 크기가 너무 큽니다."),
+
+    // 404
+    EMPLOY_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "E4041", "구인 게시글을 찾을 수 없습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,11 @@ spring:
     name: app
   profiles:
     include: secret
+
+  # 페이지네이션
+  data:
+    web:
+      pageable:
+        default-page-size: 15   # 기본 15
+        max-page-size: 50       # 최대 50
+        one-indexed-parameters: false


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#8 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

 ### EmployPostService ( 인증 구현 후 수정 필요 )
 - QBE 사용해 region, employType, employTitle 필터링
 - 페이징 적용 , 15
 - 스크랩 여부 함께 반환
 
### GetEmployPostsController ( 인증 구현 후 수정 필요 )
- GET /api/v1/employ-posts
- 필터는 모두 선택값으로 처리
- 기본 페이지 사이즈 15, createdAt DESC 정렬

### EmployPostItemResponseDto
- 게시글 기본 정보 + 스크랩 여부

### PageListResponseDto
-  pageable 공통 응답 DTO

### postman 테스트

#### 목록 조회 성공
<img width="2048" height="1497" alt="image" src="https://github.com/user-attachments/assets/ed61bac5-357a-48fb-b7b1-188dc62d9cd0" />

####  region = SEO 적용 성공
<img width="2048" height="1476" alt="image" src="https://github.com/user-attachments/assets/e3d46df9-041f-47a3-ae33-5bd616defd92" />

####  employType = FOOD 적용 성공
<img width="2048" height="1348" alt="image" src="https://github.com/user-attachments/assets/eae0e78f-99e7-4fe8-aeb2-c9225395d06b" />

### employTitle = 브릿지 적용 성공
<img width="2048" height="1472" alt="image" src="https://github.com/user-attachments/assets/2170b040-257f-4f59-bae1-e73b81af609c" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET endpoint to browse employ posts with filters (region, type, title), pagination, and default sorting by newest.
  - Responses include a list of posts with key details and whether each post is scrapped by the current user.
  - Standardized error codes/messages for invalid search, missing title, oversized pages, and missing posts.

- Bug Fixes
  - Corrected field validation handling so error details return only when actual field errors exist.

- Chores
  - Set default page size to 15 and maximum to 50 for list endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->