### PR TITLE
[Feature#10] EmployBoard 상세 정보 글 불러오기

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
@@ -1,0 +1,38 @@
+package com.bridgeon.app.domain.board.controller;
+
+
+import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
+import com.bridgeon.app.domain.board.service.EmployDetailService;
+import com.bridgeon.app.global.dto.response.PageListResponseDto;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/employ/posts")
+@RequiredArgsConstructor
+public class GetEmployDetailController {
+
+    private final EmployDetailService employDetailService;
+
+    @GetMapping("/{employBoardId}")
+    public ResponseEntity<ResponseDto<EmployPostItemResponseDto>> getEmployBoardDetail(
+            @PathVariable Long employBoardId
+    ) {
+        var item = employDetailService.getDetail(employBoardId);
+
+        return ResponseEntity.ok(
+                ResponseDto.success(
+                        HttpStatus.OK,
+                        "OK",
+                        item
+                )
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployBoardJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repositroy/EmployBoardJpaRepository.java
@@ -1,8 +1,16 @@
 package com.bridgeon.app.domain.board.repositroy;
 
 import com.bridgeon.app.domain.board.entity.EmployBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface EmployBoardJpaRepository extends JpaRepository<EmployBoard, Long> {
+import java.util.Optional;
 
+public interface EmployBoardJpaRepository extends JpaRepository<EmployBoard, Long> {
+    // 목록 조회
+    Page<EmployBoard> findAllByDeletedAtIsNull(Pageable pageable);
+
+    // 상세 조회
+    Optional<EmployBoard> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
@@ -1,0 +1,30 @@
+package com.bridgeon.app.domain.board.service;
+
+
+import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
+import com.bridgeon.app.domain.board.entity.EmployBoard;
+import com.bridgeon.app.domain.board.repositroy.EmployBoardJpaRepository;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.EmployErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class EmployDetailService {
+
+    private final EmployBoardJpaRepository employBoardJpaRepository;
+
+    public EmployPostItemResponseDto getDetail(Long employBoardId) {
+        EmployBoard board = employBoardJpaRepository.findByIdAndDeletedAtIsNull(employBoardId)
+                .orElseThrow(() -> new BusinessException(EmployErrorCode.EMPLOY_BOARD_NOT_FOUND));
+
+        // TODO: 인증 붙으면 현재 사용자 스크랩 여부 확인
+        return EmployPostItemResponseDto.of(board, false);
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#10 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### EmployBoardJpaRepository
- Optional<EmployBoard> findByIdAndDeletedAtIsNull(Long id) 추가

### GetEmployDetailController
- /api/v1/employ/posts/{employBoardId}

### 성공
<img width="2048" height="1133" alt="image" src="https://github.com/user-attachments/assets/74f4f424-0071-45c2-adfe-4cc8b141fa30" />

### 404에러 구인게시글 찾을 수 없을때
<img width="2048" height="1013" alt="image" src="https://github.com/user-attachments/assets/235a4ebd-3e5e-4300-a4e0-1e4f3b91796d" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve employment post details by ID.
  * Ensures soft-deleted posts are excluded from retrieval for accurate, up-to-date results.
  * Standardized success response format and HTTP status for consistent API consumption.
  * Lays groundwork for paginated access to employment posts (non-deleted only).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->