### PR TITLE
[Feature #12] 자유게시판 상세 글 조회 기능 구현

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetFreeDetailController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetFreeDetailController.java
@@ -1,0 +1,29 @@
+package com.bridgeon.app.domain.board.controller;
+
+import com.bridgeon.app.domain.board.dto.response.FreeDetailResponseDto;
+import com.bridgeon.app.domain.board.usecase.GetFreeDetailUseCase;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/free-boards")
+public class GetFreeDetailController {
+
+    private final GetFreeDetailUseCase getFreeDetailUseCase;
+
+    @GetMapping("/{freeBoardId}")
+    public ResponseDto<FreeDetailResponseDto> getDetail(@PathVariable Long freeBoardId) {
+        FreeDetailResponseDto result = getFreeDetailUseCase.getDetail(freeBoardId);
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "자유게시판 상세 조회 성공",
+                result
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/FreeDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/FreeDetailResponseDto.java
@@ -1,0 +1,29 @@
+package com.bridgeon.app.domain.board.dto.response;
+
+import com.bridgeon.app.domain.board.entity.FreeBoard;
+import com.bridgeon.app.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record FreeDetailResponseDto(
+        Long freeBoardId,
+        Long userId, //추후 인증구현되면 수정 예정
+        String freeBoardTitle,
+        String freeBoardContent,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+) {
+    public static FreeDetailResponseDto from(FreeBoard f) {
+        return new FreeDetailResponseDto(
+                f.getId(),
+                f.getUser() != null ? f.getUser().getId() : null, //추후에 인증 구현되면 수정 예정
+                f.getFreeBoardTitle(),
+                f.getFreeBoardContent(),
+                f.getCreatedAt(),
+                f.getUpdatedAt(),
+                f.getDeletedAt()
+        );
+
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/repositroy/FreeBoardJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repositroy/FreeBoardJpaRepository.java
@@ -1,0 +1,10 @@
+package com.bridgeon.app.domain.board.repositroy;
+
+import com.bridgeon.app.domain.board.entity.FreeBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FreeBoardJpaRepository extends JpaRepository<FreeBoard, Long> {
+    Optional<FreeBoard> findByIdAndDeletedAtIsNull(Long id);
+}

--- a/src/main/java/com/bridgeon/app/domain/board/service/FreeDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/FreeDetailService.java
@@ -1,0 +1,28 @@
+package com.bridgeon.app.domain.board.service;
+
+
+import com.bridgeon.app.domain.board.dto.response.FreeDetailResponseDto;
+import com.bridgeon.app.domain.board.entity.FreeBoard;
+import com.bridgeon.app.domain.board.repositroy.FreeBoardJpaRepository;
+import com.bridgeon.app.domain.board.usecase.GetFreeDetailUseCase;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.FreeErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FreeDetailService implements GetFreeDetailUseCase {
+
+    private final FreeBoardJpaRepository freeBoardRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public FreeDetailResponseDto getDetail(Long freeBoardId) {
+        FreeBoard freeBoard = freeBoardRepository.findByIdAndDeletedAtIsNull(freeBoardId)
+                .orElseThrow(() -> new BusinessException(FreeErrorCode.FREE_BOARD_NOT_FOUND));
+
+        return FreeDetailResponseDto.from(freeBoard);
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/usecase/GetFreeDetailUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/board/usecase/GetFreeDetailUseCase.java
@@ -1,0 +1,7 @@
+package com.bridgeon.app.domain.board.usecase;
+
+import com.bridgeon.app.domain.board.dto.response.FreeDetailResponseDto;
+
+public interface GetFreeDetailUseCase {
+    FreeDetailResponseDto getDetail(Long freeBoardId);
+}

--- a/src/main/java/com/bridgeon/app/global/exception/error/FreeErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/FreeErrorCode.java
@@ -1,0 +1,25 @@
+package com.bridgeon.app.global.exception.error;
+
+
+import com.bridgeon.app.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum FreeErrorCode implements ErrorCode {
+
+    // 400
+    TITLE_REQUIRED(HttpStatus.BAD_REQUEST.value(), "F4001", "제목은 반드시 입력해야 합니다."),
+    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), "F4002", "내용은 반드시 입력해야 합니다."),
+
+    // 404
+    FREE_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "F4041", "자유게시판 글을 찾을 수 없습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#12 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### GetFreeDetailController
- GET /api/v1/free-boards/{freeBoardId}

### FreeDetailService
- findByIdAndDeleteAtIsNull => 삭제되지 않은 글만 조회
- 없으면 FREE_BOARD_NOT_FOUND 발생

### FreeDetailResponseDto
- ID,작성자,제목,내용,생성일/수정일/삭제일 포함

### FreeBoardJpaRepository
- findByIdAndDeletedAtIsNull(Long id)
- findAllByDeletedAtIsNull(Pageable pageable)


### TEST

#### 성공
<img width="2106" height="1024" alt="image" src="https://github.com/user-attachments/assets/522ad5a5-d968-45d8-8b52-228637886905" />

#### 404에러 -> 자유게시판 글을 찾을 수 없음
<img width="2118" height="778" alt="image" src="https://github.com/user-attachments/assets/7e88bc6a-cef3-4e0f-b7e3-51403933cb95" />



## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added detailed view for Free Board posts, providing title, content, author, and created/updated timestamps.
  - New API endpoint enables fetching a single post’s full details with a success message on retrieval.

- Bug Fixes
  - Improved error responses for missing title or content and when a post is not found, returning clear, user-friendly messages and appropriate status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->