### PR TITLE
[ Fix #15 ] 구인게시판 인증 기능 연동

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
@@ -3,12 +3,16 @@ package com.bridgeon.app.domain.board.controller;
 
 import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
 import com.bridgeon.app.domain.board.service.EmployDetailService;
+import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.dto.response.PageListResponseDto;
 import com.bridgeon.app.global.dto.response.ResponseDto;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,17 +26,21 @@ public class GetEmployDetailController {
     private final EmployDetailService employDetailService;
 
     @GetMapping("/{employBoardId}")
-    public ResponseEntity<ResponseDto<EmployPostItemResponseDto>> getEmployBoardDetail(
+    public ResponseDto<EmployPostItemResponseDto> getEmployDetail(
+            @AuthenticationPrincipal User user,
             @PathVariable Long employBoardId
     ) {
-        var item = employDetailService.getDetail(employBoardId);
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
 
-        return ResponseEntity.ok(
-                ResponseDto.success(
-                        HttpStatus.OK,
-                        "OK",
-                        item
-                )
+        EmployPostItemResponseDto result = employDetailService.getDetail(employBoardId, user.getId());
+
+
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "구인게시판 상세 조회 성공",
+                result
         );
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployDetailController.java
@@ -30,11 +30,9 @@ public class GetEmployDetailController {
             @AuthenticationPrincipal User user,
             @PathVariable Long employBoardId
     ) {
-        if (user == null) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
-        }
+        Long userId = (user != null) ? user.getId() : null;
 
-        EmployPostItemResponseDto result = employDetailService.getDetail(employBoardId, user.getId());
+        EmployPostItemResponseDto result = employDetailService.getDetail(employBoardId, userId);
 
 
         return new ResponseDto<>(

--- a/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployPostsController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/GetEmployPostsController.java
@@ -5,12 +5,12 @@ import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
 import com.bridgeon.app.domain.board.service.EmployPostService;
 import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.dto.response.PageListResponseDto;
+
 import com.bridgeon.app.global.dto.response.ResponseDto;
 import com.bridgeon.app.global.enums.user.InterestField;
 import com.bridgeon.app.global.enums.user.Region;
-import com.bridgeon.app.global.exception.custom.BusinessException;
-import com.bridgeon.app.global.exception.error.EmployErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -30,23 +30,20 @@ public class GetEmployPostsController {
     private final EmployPostService employPostService;
 
     @GetMapping
-    public ResponseEntity<ResponseDto<Map<String, Object>>> getEmployPosts(
+    public ResponseDto<Map<String, Object>> getEmployPosts(
             @RequestParam(required = false) Region region,
             @RequestParam(required = false) InterestField employType,
             @RequestParam(required = false, name = "title") String employTitle,
-//            @AuthenticationPrincipal User user,
-            @RequestAttribute(name = "userId", required = false) Long userId,
+            @AuthenticationPrincipal User user,
             @PageableDefault(size = 15, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        var pageResult = employPostService.getEmployPosts(
-            region, employType, employTitle, pageable, userId
+        Long userId = (user != null) ? user.getId() : null;
+        Page<EmployPostItemResponseDto> pageResult = employPostService.getEmployPosts(
+                region, employType, employTitle, pageable, userId
         );
 
-        //추후에 인증 구현되면 바꾸기
-//        var resultPage = employPostService.getEmployPosts(region, employType, title, pageable, user.getId());
         PageListResponseDto<EmployPostItemResponseDto> dto = PageListResponseDto.of(pageResult);
-
 
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("employPosts", dto.items());
@@ -57,11 +54,10 @@ public class GetEmployPostsController {
         data.put("hasNext", dto.hasNext());
         data.put("hasPrev", dto.hasPrev());
 
-        return ResponseEntity.ok(ResponseDto.success(
-                HttpStatus.OK,
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
                 "OK",
                 data
-            )
         );
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
@@ -4,27 +4,28 @@ package com.bridgeon.app.domain.board.service;
 import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
 import com.bridgeon.app.domain.board.entity.EmployBoard;
 import com.bridgeon.app.domain.board.repositroy.EmployBoardJpaRepository;
+import com.bridgeon.app.domain.board.repositroy.EmployScrapJpaRepository;
 import com.bridgeon.app.global.exception.custom.BusinessException;
 import com.bridgeon.app.global.exception.error.EmployErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class EmployDetailService {
 
     private final EmployBoardJpaRepository employBoardJpaRepository;
+    private final EmployScrapJpaRepository employScrapJpaRepository;
 
-    public EmployPostItemResponseDto getDetail(Long employBoardId) {
+    public EmployPostItemResponseDto getDetail(Long employBoardId, Long userId) {
         EmployBoard board = employBoardJpaRepository.findByIdAndDeletedAtIsNull(employBoardId)
                 .orElseThrow(() -> new BusinessException(EmployErrorCode.EMPLOY_BOARD_NOT_FOUND));
 
-        // TODO: 인증 붙으면 현재 사용자 스크랩 여부 확인
+
+        boolean isScraped = employScrapJpaRepository.existsByUserIdAndEmployBoardId(userId, board.getId());
+
+
         return EmployPostItemResponseDto.of(board, false);
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#15 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### GetEmployDetailController
- 인증 기능 추가

### EmployDetailService
- 로그인 사용자의 스크랩 여부 반영 ( 인증 기능 연동 )

### GetEmployPostsController
-  @AuthenticationPrincipal User user 사용
- var 제거하고 타입 명시

### EmployPostService
- 사용자별 isScraped 반영 (존재 여부 체크)

### 구인게시판 글 목록 불러오기 

#### 성공
<img width="2048" height="1486" alt="image" src="https://github.com/user-attachments/assets/1335191d-3199-4cad-9b52-26d1d21691d1" />

#### 검색 필터 정상 동작 확인
<img width="2058" height="1304" alt="image" src="https://github.com/user-attachments/assets/e7f4af7a-8a60-41c5-a44c-a54bd4c7f408" />

### 구인게시판 글 상세보기

#### 성공
<img width="2080" height="1436" alt="image" src="https://github.com/user-attachments/assets/ea7b7fdf-b18b-447f-ba89-0d2b45dda91c" />

#### 구인게시판 글이 없을떄 404에러
<img width="2090" height="1210" alt="image" src="https://github.com/user-attachments/assets/b539d127-3521-492e-8563-d2a53853cf5b" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Employ posts list now includes additional pagination details: size, total elements, and total pages.
- Refactor
  - Endpoints now use authenticated user context for personalized responses where applicable.
  - Standardized API responses to return a direct response body with status and message.
  - Localized success messaging for employ board detail retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->