### PR TITLE
[ Feature #20 ] 창업정보 조회 로직 작성

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/info/controller/GetFoundationInfoListController.java
+++ b/src/main/java/com/bridgeon/app/domain/info/controller/GetFoundationInfoListController.java
@@ -1,0 +1,36 @@
+package com.bridgeon.app.domain.info.controller;
+
+
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoItemResponseDto;
+import com.bridgeon.app.domain.info.usecase.FoundationInfoListUseCase;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/foundation-info-list")
+public class GetFoundationInfoListController {
+
+    private final FoundationInfoListUseCase listUseCase;
+
+    @GetMapping
+    public ResponseDto<Page<FoundationInfoItemResponseDto>> getFoundationInfos(
+            @PageableDefault(size = 15, sort = "infoStartDate", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ){
+        Page<FoundationInfoItemResponseDto> result = listUseCase.getList(pageable);
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "창업 정보 목록 조회 성공",
+                result
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoItemResponseDto.java
@@ -1,0 +1,25 @@
+package com.bridgeon.app.domain.info.dto.response;
+
+import com.bridgeon.app.domain.info.entity.FoundationInfo;
+
+import java.time.LocalDateTime;
+
+public record FoundationInfoItemResponseDto(
+        Long foundationInfoId,
+        String title,
+        String subtitle,
+        LocalDateTime recruitStartAt,
+        LocalDateTime recruitEndAt,
+        String linkUrl
+) {
+    public static FoundationInfoItemResponseDto from(FoundationInfo i ) {
+        return new FoundationInfoItemResponseDto(
+                i.getId(),
+                i.getInfoTitle(),
+                i.getInfoSubtitle(),
+                i.getInfoStartDate(),
+                i.getInfoEndDate(),
+                i.getInfoLink()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
+++ b/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "foundation_infos")
 @Getter
@@ -17,6 +19,20 @@ public class FoundationInfo {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "foundation_info_id",  nullable = false)
-    private Long id;
+    private Long id; // 창업 정보 ID
 
+    @Column(name = "info_title", nullable = false)
+    private String infoTitle; // 창업 정보 제목
+
+    @Column(name = "info_subtitle", columnDefinition = "TEXT")
+    private String infoSubtitle; // 부제목
+
+    @Column(name = "info_start_date", nullable = false)
+    private LocalDateTime infoStartDate; // 모집 시작 날짜
+
+    @Column(name = "info_end_date", nullable = false)
+    private LocalDateTime infoEndDate; // 모집 마감 날짜
+
+    @Column(name = "info_link", nullable = false, columnDefinition = "TEXT")
+    private String infoLink; // 연결될 링크
 }

--- a/src/main/java/com/bridgeon/app/domain/info/repository/FoundationInfoJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/info/repository/FoundationInfoJpaRepository.java
@@ -1,0 +1,7 @@
+package com.bridgeon.app.domain.info.repository;
+
+import com.bridgeon.app.domain.info.entity.FoundationInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoundationInfoJpaRepository extends JpaRepository<FoundationInfo, Long> {
+}

--- a/src/main/java/com/bridgeon/app/domain/info/service/FoundationInfoListService.java
+++ b/src/main/java/com/bridgeon/app/domain/info/service/FoundationInfoListService.java
@@ -1,0 +1,32 @@
+package com.bridgeon.app.domain.info.service;
+
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoItemResponseDto;
+import com.bridgeon.app.domain.info.repository.FoundationInfoJpaRepository;
+import com.bridgeon.app.domain.info.usecase.FoundationInfoListUseCase;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.InfoErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FoundationInfoListService implements FoundationInfoListUseCase {
+
+    private final FoundationInfoJpaRepository foundationInfoJpaRepository;
+
+    @Override
+    public Page<FoundationInfoItemResponseDto> getList(Pageable pageable) {
+        Page<FoundationInfoItemResponseDto> page = foundationInfoJpaRepository
+                .findAll(pageable)
+                .map(FoundationInfoItemResponseDto::from);
+
+        // 결과가 비어 있으면 BusinessException 발생
+        if (page.isEmpty()) {
+            throw new BusinessException(InfoErrorCode.FOUNDATION_INFO_NOT_FOUND);
+        }
+
+        return page;
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/info/usecase/FoundationInfoListUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/info/usecase/FoundationInfoListUseCase.java
@@ -1,0 +1,9 @@
+package com.bridgeon.app.domain.info.usecase;
+
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoItemResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FoundationInfoListUseCase {
+    Page<FoundationInfoItemResponseDto> getList(Pageable pageable);
+}

--- a/src/main/java/com/bridgeon/app/global/exception/error/InfoErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/InfoErrorCode.java
@@ -1,0 +1,24 @@
+package com.bridgeon.app.global.exception.error;
+
+
+import com.bridgeon.app.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum InfoErrorCode implements ErrorCode {
+
+    // 404
+    FOUNDATION_INFO_NOT_FOUND(404, "FND_4001", "조회 가능한 창업 정보가 없습니다."),
+
+    // 400
+    INVALID_PAGE_REQUEST(400, "FND_4002", "잘못된 페이지 요청입니다."),
+    INVALID_DATE_RANGE(400, "FND_4003", "잘못된 날짜 범위입니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#20 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### FoundationInfoJpaRepository
- 창업 정보 조회용 레포지토리

### FoundationInfoListService
- 조회 결과가 비어 있으면 BusinessException 발생

### GetFoundationInfoListController
- GET /api/v1/foundation-info-list

### 테스트 성공
<img width="2052" height="1516" alt="image" src="https://github.com/user-attachments/assets/b3348940-47f2-4400-8c19-55c505a62b5b" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.