### PR TITLE
[ feature #22 ] 추천 창업 정보 목록 불러오기

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/info/controller/GetFoundationInfoListController.java
+++ b/src/main/java/com/bridgeon/app/domain/info/controller/GetFoundationInfoListController.java
@@ -2,7 +2,9 @@ package com.bridgeon.app.domain.info.controller;
 
 
 import com.bridgeon.app.domain.info.dto.response.FoundationInfoItemResponseDto;
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoRecommendResponseDto;
 import com.bridgeon.app.domain.info.usecase.FoundationInfoListUseCase;
+import com.bridgeon.app.domain.info.usecase.FoundationInfoRecommendUseCase;
 import com.bridgeon.app.global.dto.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,7 +22,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class GetFoundationInfoListController {
 
     private final FoundationInfoListUseCase listUseCase;
+    private final FoundationInfoRecommendUseCase recommendUseCase;
 
+
+    //기준 목록 (시작일 기준 desc)
     @GetMapping
     public ResponseDto<Page<FoundationInfoItemResponseDto>> getFoundationInfos(
             @PageableDefault(size = 15, sort = "infoStartDate", direction = Sort.Direction.DESC)
@@ -30,6 +35,20 @@ public class GetFoundationInfoListController {
         return new ResponseDto<>(
                 HttpStatus.OK.value(),
                 "창업 정보 목록 조회 성공",
+                result
+        );
+    }
+
+    //추천 목록 (조회수 기준 desc)
+    @GetMapping("/recommend")
+    public ResponseDto<Page<FoundationInfoRecommendResponseDto>> getRecommendInfos(
+            @PageableDefault(size = 15, sort = "view", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ){
+        Page<FoundationInfoRecommendResponseDto> result = recommendUseCase.getRecommendList(pageable);
+        return new ResponseDto<>(
+                HttpStatus.OK.value(),
+                "추천 창업 정보 목록 조회 성공",
                 result
         );
     }

--- a/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoRecommendResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoRecommendResponseDto.java
@@ -1,0 +1,27 @@
+package com.bridgeon.app.domain.info.dto.response;
+
+import com.bridgeon.app.domain.info.entity.FoundationInfo;
+
+import java.time.LocalDateTime;
+
+public record FoundationInfoRecommendResponseDto(
+        Long foundationInfoId,
+        String title,
+        String subtitle,
+        LocalDateTime recruitStartAt,
+        LocalDateTime recruitEndAt,
+        String linkUrl,
+        Integer view
+) {
+    public static FoundationInfoRecommendResponseDto from(FoundationInfo e) {
+        return new FoundationInfoRecommendResponseDto(
+                e.getId(),
+                e.getInfoTitle(),
+                e.getInfoSubtitle(),
+                e.getInfoStartDate(),
+                e.getInfoEndDate(),
+                e.getInfoLink(),
+                e.getView()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
+++ b/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
@@ -35,4 +35,8 @@ public class FoundationInfo {
 
     @Column(name = "info_link", nullable = false, columnDefinition = "TEXT")
     private String infoLink; // 연결될 링크
+
+    @Column(name = "view", nullable = false)
+    @Builder.Default
+    private Integer view = 0;
 }

--- a/src/main/java/com/bridgeon/app/domain/info/repository/FoundationInfoJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/info/repository/FoundationInfoJpaRepository.java
@@ -1,7 +1,11 @@
 package com.bridgeon.app.domain.info.repository;
 
 import com.bridgeon.app.domain.info.entity.FoundationInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FoundationInfoJpaRepository extends JpaRepository<FoundationInfo, Long> {
+    //조회수 기준 내림차순
+    Page<FoundationInfo> findAllByOrderByViewDesc(Pageable pageable);
 }

--- a/src/main/java/com/bridgeon/app/domain/info/service/FoundationInfoRecommendService.java
+++ b/src/main/java/com/bridgeon/app/domain/info/service/FoundationInfoRecommendService.java
@@ -1,0 +1,31 @@
+package com.bridgeon.app.domain.info.service;
+
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoRecommendResponseDto;
+import com.bridgeon.app.domain.info.repository.FoundationInfoJpaRepository;
+import com.bridgeon.app.domain.info.usecase.FoundationInfoRecommendUseCase;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.InfoErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FoundationInfoRecommendService implements FoundationInfoRecommendUseCase {
+
+    private final FoundationInfoJpaRepository foundationInfoJpaRepository;
+
+    @Override
+    public Page<FoundationInfoRecommendResponseDto> getRecommendList(Pageable pageable) {
+        Page<FoundationInfoRecommendResponseDto> page =
+                foundationInfoJpaRepository.findAllByOrderByViewDesc(pageable)
+                        .map(FoundationInfoRecommendResponseDto::from);
+
+        if (page.isEmpty()) {
+            throw new BusinessException(InfoErrorCode.FOUNDATION_INFO_NOT_FOUND);
+        }
+        return page;
+    }
+
+}

--- a/src/main/java/com/bridgeon/app/domain/info/usecase/FoundationInfoRecommendUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/info/usecase/FoundationInfoRecommendUseCase.java
@@ -1,0 +1,9 @@
+package com.bridgeon.app.domain.info.usecase;
+
+import com.bridgeon.app.domain.info.dto.response.FoundationInfoRecommendResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface FoundationInfoRecommendUseCase {
+    Page<FoundationInfoRecommendResponseDto> getRecommendList(Pageable pageable);
+}


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#22 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)
- 엔티티 / ERD에 view 추가

### FoundationInfoRecommendResponseDto
- 기존 FoundationInfoItemResponseDto 에 view 추가

### FoundationInfoRecommendService
- FoundationInfoRecommendUseCase 구현체

### GetFoundationInfoListController
- GET /api/v1/foundation-info-list/recommend
- 조회수 기준 내림차순 정렬

### 테스트 성공
<img width="2084" height="1518" alt="image" src="https://github.com/user-attachments/assets/4e3b21f3-384f-4044-b97b-85804797c4b0" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.