### PR TITLE
[ Fix #24 ] 창업 정보 목록 기능에 이미지URL 추가

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoItemResponseDto.java
@@ -8,15 +8,17 @@ public record FoundationInfoItemResponseDto(
         Long foundationInfoId,
         String title,
         String subtitle,
+        String imageUrl,
         LocalDateTime recruitStartAt,
         LocalDateTime recruitEndAt,
-        String linkUrl
+        String infoLink
 ) {
     public static FoundationInfoItemResponseDto from(FoundationInfo i ) {
         return new FoundationInfoItemResponseDto(
                 i.getId(),
                 i.getInfoTitle(),
                 i.getInfoSubtitle(),
+                i.getInfoImageUrl(),
                 i.getInfoStartDate(),
                 i.getInfoEndDate(),
                 i.getInfoLink()

--- a/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoRecommendResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/info/dto/response/FoundationInfoRecommendResponseDto.java
@@ -8,9 +8,10 @@ public record FoundationInfoRecommendResponseDto(
         Long foundationInfoId,
         String title,
         String subtitle,
+        String infoImageUrl,
         LocalDateTime recruitStartAt,
         LocalDateTime recruitEndAt,
-        String linkUrl,
+        String infoLink,
         Integer view
 ) {
     public static FoundationInfoRecommendResponseDto from(FoundationInfo e) {
@@ -18,6 +19,7 @@ public record FoundationInfoRecommendResponseDto(
                 e.getId(),
                 e.getInfoTitle(),
                 e.getInfoSubtitle(),
+                e.getInfoImageUrl(),
                 e.getInfoStartDate(),
                 e.getInfoEndDate(),
                 e.getInfoLink(),

--- a/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
+++ b/src/main/java/com/bridgeon/app/domain/info/entity/FoundationInfo.java
@@ -27,6 +27,9 @@ public class FoundationInfo {
     @Column(name = "info_subtitle", columnDefinition = "TEXT")
     private String infoSubtitle; // 부제목
 
+    @Column(name = "info_image_url", nullable = false, columnDefinition = "TEXT")
+    private String infoImageUrl; // 이미지 URL
+
     @Column(name = "info_start_date", nullable = false)
     private LocalDateTime infoStartDate; // 모집 시작 날짜
 


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#24 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

- foundationInfoEntity에 infoImageUrl 추가
- 응답DTO에 infoImageUrl 추가

### 테스트
<img width="1522" height="1122" alt="image" src="https://github.com/user-attachments/assets/9b3f0803-419b-4aa7-8534-2769d9181eb4" />

<img width="1618" height="1320" alt="image" src="https://github.com/user-attachments/assets/1e8ea2b0-2d49-48a1-9df2-ffcb24e4e442" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.