### PR TITLE
[ Feature #28 ] 열람 승인 / 거절 기능 작성

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/controller/EmployApplicationController.java
+++ b/src/main/java/com/bridgeon/app/domain/board/controller/EmployApplicationController.java
@@ -4,54 +4,65 @@ package com.bridgeon.app.domain.board.controller;
 import com.bridgeon.app.domain.board.usecase.EmployApplicationUseCase;
 import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.dto.response.ResponseDto;
-import com.bridgeon.app.global.exception.custom.BusinessException;
-import com.bridgeon.app.global.exception.error.AuthErrorCode;
-import com.bridgeon.app.global.jwt.utils.JwtUtils;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/employ/posts")
 @RequiredArgsConstructor
 public class EmployApplicationController {
 
     private final EmployApplicationUseCase employApplicationUseCase;
-    private final JwtUtils jwtUtils;
 
     // 지원하기
     @PostMapping("/{employBoardId}/applications")
     public ResponseDto<Long> apply(
-            @AuthenticationPrincipal Object principal,  // <- SpEL 제거, Object로 받기
+            @AuthenticationPrincipal User user,
             @PathVariable Long employBoardId
     ) {
-        // 인증 체크: 토큰 만료/미포함이면 Anonymous로 들어와서 String 입니다.
-        if (!(principal instanceof org.springframework.security.core.userdetails.User u)) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
-        }
-
-
-        // JwtUtils.getAuthentication()에서 subject를 username으로 넣었으므로 그대로 사용
-        String userIdStr = u.getUsername();
-
-        Long applicantId;
-        try {
-            applicantId = Long.parseLong(userIdStr);
-        } catch (NumberFormatException e) {
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
-        }
-
-        Long applicationId = employApplicationUseCase.apply(employBoardId, applicantId);
+        Long applicationId = employApplicationUseCase.apply(employBoardId, user.getId());
 
         return new ResponseDto<>(
                 HttpStatus.CREATED.value(),
                 "지원이 접수되었습니다.",
                 applicationId
         );
+    }
+
+    // 지원 승인 (작성자)
+    @PostMapping("/{employBoardId}/applications/{applicationId}/approve")
+    public ResponseDto<Void> approve(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long employBoardId,
+            @PathVariable Long applicationId
+    ) {
+        employApplicationUseCase.approve(employBoardId, applicationId, user.getId());
+        return new ResponseDto<>(HttpStatus.OK.value(), "승인 완료", null);
+    }
+
+    // 지원 거절 (작성자)
+    @PostMapping("/{employBoardId}/applications/{applicationId}/reject")
+    public ResponseDto<Void> reject(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long employBoardId,
+            @PathVariable Long applicationId
+    ) {
+        employApplicationUseCase.reject(employBoardId, applicationId, user.getId());
+        return new ResponseDto<>(HttpStatus.OK.value(), "거절 완료", null);
+    }
+
+    // 지원 취소 (지원자)
+    @DeleteMapping("/{employBoardId}/applications/{applicationId}")
+    public ResponseDto<Void> cancel(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long employBoardId,
+            @PathVariable Long applicationId
+    ) {
+        employApplicationUseCase.cancel(employBoardId, applicationId, user.getId());
+        return new ResponseDto<>(HttpStatus.OK.value(), "취소 완료", null);
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployApplicationServiceImpl.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployApplicationServiceImpl.java
@@ -15,13 +15,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EmployApplicationServiceImpl implements EmployApplicationUseCase {
-
 
     private final EmployApplicationJpaRepository applicationRepository;
     private final EmployBoardJpaRepository boardRepository;
@@ -63,5 +63,84 @@ public class EmployApplicationServiceImpl implements EmployApplicationUseCase {
         saved = applicationRepository.save(saved);
 
         return saved.getId();
+    }
+
+    // 승인하기
+    @Override
+    @Transactional
+    public void approve(Long employBoardId, Long applicationId, Long ownerId) {
+
+        // 신청 존재 확인
+        EmployApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND));
+
+        // 글 작성자인지 확인
+        validateOwnership(app, employBoardId, ownerId);
+
+        // 승인으로 업데이트
+        int updated = applicationRepository.updateStatus(
+                applicationId,
+                ApplyStatus.APPROVED,
+                LocalDateTime.now()
+        );
+        // 업데이트 된 행이 없을 때 -> 예외 던짐
+        if (updated == 0) throw new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND);
+    }
+
+    // 거절하기
+    @Override
+    @Transactional
+    public void reject(Long employBoardId, Long applicationId, Long ownerId) {
+
+        // 신청 존재 확인
+        EmployApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND));
+
+        // 글 작성자인지 확인
+        validateOwnership(app, employBoardId, ownerId);
+
+        // 거절으로 업데이트
+        int updated = applicationRepository.updateStatus(
+                applicationId,
+                ApplyStatus.REJECTED,
+                LocalDateTime.now()
+        );
+        //업데이트 된 행이 없을 때 -> 예외 던짐
+        if (updated == 0) throw new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND);
+    }
+
+    // 지원 취소
+    @Override
+    @Transactional
+    public void cancel(Long employBoardId, Long applicationId, Long ownerId) {
+        // 신청 존재 확인
+        EmployApplication app = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND));
+
+        // 경로 검증
+        if (!app.getEmployBoard().getId().equals(employBoardId)) {
+            throw new BusinessException(EmployErrorCode.APPLICATION_NOT_FOUND);
+        }
+
+        //신청자 본인만 취소 가능
+        if (!app.getApplicant().getId().equals(applicationId)) {
+            throw new BusinessException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        //softdelete 구현
+        applicationRepository.softDelete(applicationId, LocalDateTime.now());
+    }
+
+
+    private void validateOwnership(EmployApplication app, Long employBoardId, Long ownerId) {
+        // 신청이 해당 게시글에 속해 있는지 확인
+        if (!app.getEmployBoard().getId().equals(employBoardId)) {
+            throw new BusinessException(EmployErrorCode.EMPLOY_APPLICATION_NOT_FOUND);
+        }
+
+        // 게시글 작성자(ownerId)와 요청한 사용자(ownerId)가 일치하는지 확인
+        if (!app.getEmployBoard().getUser().getId().equals(ownerId)) {
+            throw new BusinessException(AuthErrorCode.ACCESS_DENIED);
+        }
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/usecase/EmployApplicationUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/board/usecase/EmployApplicationUseCase.java
@@ -2,5 +2,16 @@ package com.bridgeon.app.domain.board.usecase;
 
 
 public interface EmployApplicationUseCase {
+
+    // 지원하기
     Long apply(Long employBoardId, Long applicantId);
+
+    // 구인게시판 글 작성자가 승인
+    void approve(Long employBoardId, Long applicationId, Long ownerId);
+
+    // 구인게시판 글 작성자가 거절
+    void reject(Long employBoardId, Long applicationId, Long ownerId);
+
+    // 지원자가 취소
+    void cancel(Long employBoardId, Long applicationId, Long applicantId);
 }

--- a/src/main/java/com/bridgeon/app/global/exception/error/AuthErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/AuthErrorCode.java
@@ -18,7 +18,7 @@ public enum AuthErrorCode implements ErrorCode {
     PERMISSION_CONSENT(HttpStatus.BAD_REQUEST.value(), "A4004", "카카오 계정 권한 동의 필요"),
 
     // 401
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(),"A4011", "인증되지 않은 사용자압니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(),"A4011", "인증되지 않은 사용자입니다."),
 
     // 403
     ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "A4031", "접근 권한이 없습니다."),

--- a/src/main/java/com/bridgeon/app/global/exception/error/EmployErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/EmployErrorCode.java
@@ -23,7 +23,8 @@ public enum EmployErrorCode implements ErrorCode {
 
     // 404 리소스 없음
     EMPLOY_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "E4041", "구인 게시글을 찾을 수 없습니다."),
-    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "E4042", "지원 내역을 찾을 수 없습니다.");
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "E4042", "지원 내역을 찾을 수 없습니다."),
+    EMPLOY_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "E4043", "구인 신청 내역을 찾을 수 없습니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/com/bridgeon/app/global/jwt/service/AccessTokenGenerateService.java
+++ b/src/main/java/com/bridgeon/app/global/jwt/service/AccessTokenGenerateService.java
@@ -5,11 +5,13 @@ import com.bridgeon.app.global.jwt.properties.JwtProperties;
 import com.bridgeon.app.global.jwt.usecase.TokenGenerateUseCase;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AccessTokenGenerateService implements TokenGenerateUseCase {
@@ -21,6 +23,7 @@ public class AccessTokenGenerateService implements TokenGenerateUseCase {
     public String generateToken(AuthInfo authInfo) {
         Date now = new Date();
         Long expiration = jwt.getExpirationTime().getAccessToken();
+        log.info(expiration.toString());
 
         return Jwts.builder()
                 .setSubject(authInfo.id().toString())

--- a/src/main/java/com/bridgeon/app/global/jwt/utils/JwtFilter.java
+++ b/src/main/java/com/bridgeon/app/global/jwt/utils/JwtFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
@@ -28,7 +30,11 @@ public class JwtFilter extends OncePerRequestFilter {
             FilterChain chain
     ) throws ServletException, IOException {
 
+        log.info("[JWT] >>> {} {} from {}", req.getMethod(), req.getRequestURI(), req.getRemoteAddr());
+
         String jwt = resolveToken(req);
+
+        log.info("[JWT] extracted token: {}", jwt != null ? "[PRESENT]" : "[NULL]");
 
         if (StringUtils.hasText(jwt) && jwtUtils.validateToken(jwt)) {
             Authentication authentication = jwtUtils.getAuthentication(jwt);

--- a/src/main/java/com/bridgeon/app/global/jwt/utils/JwtUtils.java
+++ b/src/main/java/com/bridgeon/app/global/jwt/utils/JwtUtils.java
@@ -1,6 +1,9 @@
 package com.bridgeon.app.global.jwt.utils;
 
+import com.bridgeon.app.domain.user.repository.UserRepository;
 import com.bridgeon.app.global.dto.auth.AuthInfo;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
 import com.bridgeon.app.global.jwt.usecase.TokenGenerateUseCase;
 import io.jsonwebtoken.*;
 import lombok.extern.slf4j.Slf4j;
@@ -21,15 +24,17 @@ public class JwtUtils {
     private final SecretKey secretKey;
     public final TokenGenerateUseCase accessTokenGenerateService;
     public final TokenGenerateUseCase refreshTokenGenerateService;
+    private final UserRepository userRepository;
 
     public JwtUtils(
             SecretKey secretKey,
             @Qualifier("accessTokenGenerateService") TokenGenerateUseCase accessTokenGenerateService,
-            @Qualifier("refreshTokenGenerateService") TokenGenerateUseCase refreshTokenGenerateService
-    ) {
+            @Qualifier("refreshTokenGenerateService") TokenGenerateUseCase refreshTokenGenerateService,
+            UserRepository userRepository) {
         this.secretKey = secretKey;
         this.accessTokenGenerateService = accessTokenGenerateService;
         this.refreshTokenGenerateService = refreshTokenGenerateService;
+        this.userRepository = userRepository;
     }
 
 
@@ -84,16 +89,15 @@ public class JwtUtils {
         Claims claims = getClaimsFromToken(accessToken);
         String role = claims.get("role", String.class);
 
-        User principal = new User(
-                claims.getSubject(),
-                "",
-                Collections.singleton(new SimpleGrantedAuthority(role))
-        );
+        Long userId = Long.parseLong(claims.getSubject());
+        com.bridgeon.app.domain.user.entity.User entity =
+                userRepository.findById(userId)
+                        .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
 
         return new UsernamePasswordAuthenticationToken(
-                principal,
+                entity, // 이제 엔티티가 principal
                 accessToken,
-                principal.getAuthorities()
+                Collections.singleton(new SimpleGrantedAuthority(role))
         );
     }
 }

--- a/src/test/java/com/bridgeon/app/auth/AuthTest.java
+++ b/src/test/java/com/bridgeon/app/auth/AuthTest.java
@@ -61,7 +61,7 @@ public class AuthTest extends BaseTest {
 
     @Test
     void 기존_사용자_토큰발급() {
-        Long userId = 1L; // id 수정해서 사용
+        Long userId = 13L; // id 수정해서 사용
 
         User existing = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#28 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### EmployApplicationController
- 지원하기 (apply)
- 승인하기 (approve)
- 거절하기 (reject)
- 취소하기 (cancel) 
- POST /api/v1/employ/posts/{employBoardId}/applications → 지원 성공
- POST /api/v1/employ/posts/{employBoardId}/applications/{applicationId}/approve → 승인 성공
- POST /api/v1/employ/posts/{employBoardId}/applications/{applicationId}/reject → 거절 성공
- DELETE /api/v1/employ/posts/{employBoardId}/applications/{applicationId} → 취소 성공

### 테스트

#### 열람 승인 성공
<img width="2070" height="854" alt="image" src="https://github.com/user-attachments/assets/4d6bbf89-c58d-4f4b-bd64-fefc359dbb61" />
<img width="1916" height="290" alt="image" src="https://github.com/user-attachments/assets/c195797f-d61f-4d70-a329-16f4df2880cf" />
-> PENDING 에서 APPROVED 로 변경됨

#### 열람 거절 성공
<img width="2080" height="672" alt="image" src="https://github.com/user-attachments/assets/6684013d-4df8-4cfd-a986-6b9d026b5254" />
<img width="1888" height="238" alt="image" src="https://github.com/user-attachments/assets/18144b8a-fe0b-46ad-9aa7-97163e704c8e" />
-> PENDING 에서 REJECTED 로 변경됨


#### 에러

##### 404 에러 , 구인 신청 내역을 찾을 수 없음 , 신청하지 않았을때
<img width="2098" height="866" alt="image" src="https://github.com/user-attachments/assets/de9ccc8d-8ca6-4497-9fe0-43b2280a5a58" />

##### 404 에러, 지원 내역을 찾을 수 없음 , applicationId 가 없는것을 요청했을때
<img width="2092" height="890" alt="image" src="https://github.com/user-attachments/assets/eeb1c6bc-f612-4bd5-9145-88d5129c5b27" />



## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.