### PR TITLE
[ Feature #34 ] 지원자 프로필 상세 조회

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/user/controller/ApplicantDetailController.java
+++ b/src/main/java/com/bridgeon/app/domain/user/controller/ApplicantDetailController.java
@@ -1,0 +1,41 @@
+package com.bridgeon.app.domain.user.controller;
+
+
+import com.bridgeon.app.domain.user.dto.response.ApplicantDetailResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.usecase.GetApplicantDetailUseCase;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class ApplicantDetailController {
+
+    private final GetApplicantDetailUseCase getApplicantDetailUseCase;
+
+
+    //지원자 프로필 + 포토폴리오 상세 조회
+    @GetMapping("/{applicantUserId}/detail")
+    public ResponseDto<ApplicantDetailResponseDto> getApplicantDetail(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long applicantUserId) {
+
+        Long currentUserId = (user == null) ? null : user.getId();
+
+        ApplicantDetailResponseDto dto =
+                getApplicantDetailUseCase.excute(applicantUserId, currentUserId);
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "지원자 상세 조회 성공",
+                dto
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantDetailResponseDto.java
@@ -1,0 +1,13 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import java.util.List;
+
+public record ApplicantDetailResponseDto(
+        ApplicantProfileResponseDto profile,
+        java.util.List<PortfolioDetailItemResponseDto> portfolios
+) {
+    public static ApplicantDetailResponseDto of(ApplicantProfileResponseDto profile, List<PortfolioDetailItemResponseDto> portfolios) {
+
+        return new ApplicantDetailResponseDto(profile, portfolios);
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantProfileResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantProfileResponseDto.java
@@ -1,0 +1,30 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record ApplicantProfileResponseDto(
+        Long userId,
+        String name,
+        String nickname,
+        String email,
+        String region,
+        String interestField,
+        String introduction,
+        LocalDateTime createdAt
+) {
+    public static ApplicantProfileResponseDto of(User u) {
+        return new ApplicantProfileResponseDto(
+                u.getId(),
+                u.getName(),
+                u.getNickname(),
+                u.getEmail(),
+                u.getRegion().name(),
+                u.getInterestField().name(),
+                u.getIntroduction(),
+                u.getCreatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioDetailItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioDetailItemResponseDto.java
@@ -1,0 +1,33 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.domain.user.entity.Portfolio;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.global.enums.portfolio.Visibility;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record PortfolioDetailItemResponseDto(
+        Long portfolioId,
+        String title,
+        LocalDate periodStart,
+        LocalDate periodEnd,
+        String introduction,
+        String fileUrl,       // 파일·첨부는 추후 Attachments 연동 시 매핑
+        Visibility visibility,
+        LocalDateTime createdAt
+) {
+    public static PortfolioDetailItemResponseDto of(Portfolio p) {
+        return new PortfolioDetailItemResponseDto(
+                p.getId(),
+                p.getTitle(),
+                p.getStartDate() != null ? p.getStartDate().toLocalDate() : null,
+                p.getEndDate() != null ? p.getEndDate().toLocalDate() : null,
+                p.getIntroduction(),
+                null, // fileUrl은 Attachments 구현 시 채울 예정
+                p.getVisibility(),
+                p.getCreatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/bridgeon/app/domain/user/entity/Portfolio.java
+++ b/src/main/java/com/bridgeon/app/domain/user/entity/Portfolio.java
@@ -27,6 +27,7 @@ public class Portfolio extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "visibility", nullable = false)
     private Visibility visibility; // 공개 여부
 

--- a/src/main/java/com/bridgeon/app/domain/user/repository/PortfolioJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/user/repository/PortfolioJpaRepository.java
@@ -1,0 +1,12 @@
+package com.bridgeon.app.domain.user.repository;
+
+import com.bridgeon.app.domain.user.entity.Portfolio;
+import com.bridgeon.app.global.enums.portfolio.Visibility;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PortfolioJpaRepository extends JpaRepository<Portfolio, Long> {
+        List<Portfolio> findByUser_IdOrderByCreatedAtDesc(Long userId);
+        List<Portfolio> findByUser_IdAndVisibilityOrderByCreatedAtDesc(Long userId, Visibility visibility);
+}

--- a/src/main/java/com/bridgeon/app/domain/user/service/ApplicantDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/user/service/ApplicantDetailService.java
@@ -1,0 +1,51 @@
+package com.bridgeon.app.domain.user.service;
+
+import com.bridgeon.app.domain.user.dto.response.ApplicantDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.ApplicantProfileResponseDto;
+import com.bridgeon.app.domain.user.dto.response.PortfolioDetailItemResponseDto;
+import com.bridgeon.app.domain.user.entity.Portfolio;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.repository.PortfolioJpaRepository;
+import com.bridgeon.app.domain.user.repository.UserRepository;
+import com.bridgeon.app.domain.user.usecase.GetApplicantDetailUseCase;
+import com.bridgeon.app.global.enums.portfolio.Visibility;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class ApplicantDetailService implements GetApplicantDetailUseCase {
+
+    private final UserRepository userRepository;
+    private final PortfolioJpaRepository portfolioJpaRepository;
+
+    @Override
+    public ApplicantDetailResponseDto excute(Long applicantUserId, Long currentUserId) {
+
+        User applicant = userRepository.findById(applicantUserId)
+                .orElseThrow(() -> new BusinessException((AuthErrorCode.USER_NOT_FOUND)));
+
+        // 내 mypage O -> 전부 공개, 아니면 PUBLIC만 노출
+        boolean isMyPage = currentUserId != null && currentUserId.equals(applicantUserId);
+
+        List<Portfolio> portfolios = portfolioJpaRepository.findByUser_IdOrderByCreatedAtDesc(applicantUserId);
+
+        List<PortfolioDetailItemResponseDto> portfolioDto = portfolios.stream()
+                .filter(p -> isMyPage || p.getVisibility() == null || p.getVisibility() == Visibility.PUBLIC)
+                .sorted(Comparator.comparing(Portfolio::getCreatedAt).reversed())
+                .map(PortfolioDetailItemResponseDto::of)
+                .toList();
+
+        ApplicantProfileResponseDto applicantProfileResponseDto = ApplicantProfileResponseDto.of(applicant);
+
+        return new ApplicantDetailResponseDto(applicantProfileResponseDto, portfolioDto);
+
+    }
+
+}

--- a/src/main/java/com/bridgeon/app/domain/user/usecase/GetApplicantDetailUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/user/usecase/GetApplicantDetailUseCase.java
@@ -1,0 +1,7 @@
+package com.bridgeon.app.domain.user.usecase;
+
+import com.bridgeon.app.domain.user.dto.response.ApplicantDetailResponseDto;
+
+public interface GetApplicantDetailUseCase {
+    ApplicantDetailResponseDto excute(Long  applicantUserId, Long currentUserId);
+}


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#34 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### ApplicantDetailController
- GET /api/v1/users/{applicantUserId}/detail
- 특정 지원자의 프로필 정보, 포토폴리오 목록을 반환

### ApplicantDetailService
- 본인(currentUserId == applicantUserId)이면 전체 반환, 아니면 PUBLIC 포트폴리오만 필터링.

### 테스트

#### userId = 13 토큰 사용, userId = 13인 사용자의 프로필 상세 조회 -> public, private이 같이 나옴
<img width="2158" height="1612" alt="image" src="https://github.com/user-attachments/assets/34cbd70d-0cfe-46cd-bad4-653b9a6f7d46" />

#### userId = 14 토큰 사용, userId = 13인 사용자의 프로필 상세 조회 -> public만 응답
<img width="2048" height="1414" alt="image" src="https://github.com/user-attachments/assets/59558b45-1985-47b2-8d8d-9f4f08040144" />



## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.