### PR TITLE
[ Feature #37 ] 사업계획서 목록/상세 조회 + 열람 권한 로직 추가

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/entity/EmployBoard.java
+++ b/src/main/java/com/bridgeon/app/domain/board/entity/EmployBoard.java
@@ -1,5 +1,6 @@
 package com.bridgeon.app.domain.board.entity;
 
+import com.bridgeon.app.domain.user.entity.BusinessPlan;
 import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.entity.BaseEntity;
 import com.bridgeon.app.global.enums.user.InterestField;
@@ -51,4 +52,8 @@ public class EmployBoard extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt; // 구인게시판 글 삭제일
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_plan_id", nullable = false)
+    private BusinessPlan businessPlan;
 }

--- a/src/main/java/com/bridgeon/app/domain/board/repository/EmployApplicationJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repository/EmployApplicationJpaRepository.java
@@ -1,6 +1,7 @@
 package com.bridgeon.app.domain.board.repository;
 
 import com.bridgeon.app.domain.board.entity.EmployApplication;
+import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.enums.board.ApplyStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -50,4 +51,10 @@ public interface EmployApplicationJpaRepository extends JpaRepository<EmployAppl
            """)
     int softDelete(@Param("applicationId") Long applicationId,
                    @Param("deletedAt") LocalDateTime deletedAt);
+
+    boolean existsByEmployBoard_BusinessPlan_IdAndApplicantAndApplyStatusAndDeletedAtIsNull(
+            Long businessPlanId,
+            User user,
+            ApplyStatus status
+    );
 }

--- a/src/main/java/com/bridgeon/app/domain/user/controller/BusinessPlanController.java
+++ b/src/main/java/com/bridgeon/app/domain/user/controller/BusinessPlanController.java
@@ -1,0 +1,60 @@
+package com.bridgeon.app.domain.user.controller;
+
+
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanListResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.usecase.BusinessPlanUseCase;
+import com.bridgeon.app.global.dto.response.PageListResponseDto;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/business-plans")
+@RequiredArgsConstructor
+public class BusinessPlanController {
+
+    private final BusinessPlanUseCase businessPlanUseCase;
+
+
+    // 사업계획서 목록 조회
+    @GetMapping("/my")
+    public ResponseDto<PageListResponseDto<BusinessPlanListResponseDto>> getMyBusinessPlans(
+            @AuthenticationPrincipal User user,
+            @PageableDefault(size = 15, sort = "createdAt") Pageable pageable
+    ) {
+        PageListResponseDto<BusinessPlanListResponseDto> dto =
+                businessPlanUseCase.getMyBusinessPlans(user.getId(), pageable);
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "내 사업계획서 목록 조회 성공",
+                dto
+        );
+    }
+
+    // 사업계획서 상세조회 조회
+    @GetMapping("/{businessPlanId}")
+    public ResponseDto<BusinessPlanDetailResponseDto> getBusinessPlanDetail(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long businessPlanId
+    ) {
+        BusinessPlanDetailResponseDto dto =
+                businessPlanUseCase.getBusinessPlanDetail(businessPlanId, user.getId());
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "사업계획서 상세 조회 성공",
+                dto
+        );
+    }
+}
+

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.domain.user.entity.BusinessPlan;
+import com.bridgeon.app.global.dto.json.businessplan.Content;
+import com.bridgeon.app.global.enums.user.InterestField;
+
+import java.time.LocalDateTime;
+
+public record BusinessPlanDetailResponseDto(
+        Long businessPlanId,
+        String title,
+        InterestField businessType,
+        Content content, //{ overview, marketAnalysis, businessModel, actionPlan }
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static BusinessPlanListResponseDto of(BusinessPlan bp) {
+        return new BusinessPlanListResponseDto(
+                bp.getId(),
+                bp.getTitle(),
+                bp.getBusinessType(),
+                bp.getCreatedAt(),
+                bp.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanListResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanListResponseDto.java
@@ -1,0 +1,25 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.domain.user.entity.BusinessPlan;
+import com.bridgeon.app.global.enums.user.InterestField;
+
+import java.time.LocalDateTime;
+
+public record BusinessPlanListResponseDto(
+        Long businessPlanId,
+        String title,
+        InterestField businessType,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static BusinessPlanListResponseDto of(BusinessPlan bp) {
+        return new BusinessPlanListResponseDto(
+                bp.getId(),
+                bp.getTitle(),
+                bp.getBusinessType(),
+                bp.getCreatedAt(),
+                bp.getUpdatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/bridgeon/app/domain/user/entity/BusinessPlan.java
+++ b/src/main/java/com/bridgeon/app/domain/user/entity/BusinessPlan.java
@@ -2,6 +2,7 @@ package com.bridgeon.app.domain.user.entity;
 
 import com.bridgeon.app.global.dto.json.businessplan.Content;
 import com.bridgeon.app.global.entity.BaseEntity;
+import com.bridgeon.app.global.enums.user.InterestField;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -29,6 +30,10 @@ public class BusinessPlan extends BaseEntity {
 
     @Column(name = "title", nullable = false)
     private String title; // 사업계획서 제목
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "business_type", nullable = false)
+    private InterestField businessType; // 사업 분야
 
     @Type(JsonType.class)
     @Column(name = "content", nullable = false, columnDefinition = "json")

--- a/src/main/java/com/bridgeon/app/domain/user/repository/BusinessPlanJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/user/repository/BusinessPlanJpaRepository.java
@@ -1,0 +1,17 @@
+package com.bridgeon.app.domain.user.repository;
+
+import com.bridgeon.app.domain.user.entity.BusinessPlan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BusinessPlanJpaRepository extends JpaRepository<BusinessPlan, Long> {
+
+    //내 목록 조회
+    Page<BusinessPlan> findByUserId(Long userId, Pageable pageable);
+
+    //상세 + 소유자 검증
+    Optional<BusinessPlan> findByIdAndUserId(Long businessPlanId, Long userId);
+}

--- a/src/main/java/com/bridgeon/app/domain/user/service/BusinessPlanServiceImpl.java
+++ b/src/main/java/com/bridgeon/app/domain/user/service/BusinessPlanServiceImpl.java
@@ -1,0 +1,80 @@
+package com.bridgeon.app.domain.user.service;
+
+import com.bridgeon.app.domain.board.repository.EmployApplicationJpaRepository;
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanListResponseDto;
+import com.bridgeon.app.domain.user.entity.BusinessPlan;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.repository.BusinessPlanJpaRepository;
+import com.bridgeon.app.domain.user.usecase.BusinessPlanUseCase;
+import com.bridgeon.app.global.dto.response.PageListResponseDto;
+import com.bridgeon.app.global.enums.board.ApplyStatus;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.BusinessPlanErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BusinessPlanServiceImpl implements BusinessPlanUseCase {
+
+    private final BusinessPlanJpaRepository repository;
+    private final EmployApplicationJpaRepository employApplicationJpaRepository;
+
+    /** 내 사업계획서 목록 조회 */
+    @Override
+    public PageListResponseDto<BusinessPlanListResponseDto> getMyBusinessPlans(Long userId, Pageable pageable) {
+        Page<BusinessPlan> page = repository.findByUserId(userId, pageable);
+        Page<BusinessPlanListResponseDto> dtoPage = page.map(BusinessPlanListResponseDto::of);
+        return PageListResponseDto.of(dtoPage);
+    }
+
+    // 사업계획서 상세 조회
+    @Override
+    public BusinessPlanDetailResponseDto getBusinessPlanDetail(Long businessPlanId, Long authUserId) {
+
+        // 1) 존재 여부
+        BusinessPlan bp = repository.findById(businessPlanId)
+                .orElseThrow(() -> new BusinessException(BusinessPlanErrorCode.BUSINESS_PLAN_NOT_FOUND));
+
+        // 2) 작성자 본인 → 바로 반환
+        if (bp.getUser().getId().equals(authUserId)) {
+            return toDetail(bp);
+        }
+
+        // 3) 작성자가 아니면 승인 여부 확인
+
+        User authUser = User.builder()
+                .id(authUserId)
+                .build();
+
+        boolean approved = employApplicationJpaRepository
+                .existsByEmployBoard_BusinessPlan_IdAndApplicantAndApplyStatusAndDeletedAtIsNull(
+                        businessPlanId,
+                        authUser,
+                        ApplyStatus.APPROVED
+                );
+
+        if (!approved) {
+            throw new BusinessException(BusinessPlanErrorCode.FORBIDDEN);
+        }
+
+        return toDetail(bp);
+    }
+
+        private BusinessPlanDetailResponseDto toDetail(BusinessPlan bp) {
+            return new BusinessPlanDetailResponseDto(
+                    bp.getId(),
+                    bp.getTitle(),
+                    bp.getBusinessType(),
+                    bp.getContent(),
+                    bp.getCreatedAt(),
+                    bp.getUpdatedAt()
+            );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/usecase/BusinessPlanUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/user/usecase/BusinessPlanUseCase.java
@@ -1,0 +1,15 @@
+package com.bridgeon.app.domain.user.usecase;
+
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.BusinessPlanListResponseDto;
+import com.bridgeon.app.global.dto.response.PageListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface BusinessPlanUseCase {
+
+    // 내가 작성한 사업계획서 목록 조회
+    PageListResponseDto<BusinessPlanListResponseDto> getMyBusinessPlans(Long userId, Pageable pageable);
+
+    // 사업계획서 상세 조회
+    BusinessPlanDetailResponseDto getBusinessPlanDetail(Long businessPlanId, Long authUserId);
+}

--- a/src/main/java/com/bridgeon/app/global/exception/error/BusinessPlanErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/BusinessPlanErrorCode.java
@@ -1,0 +1,35 @@
+package com.bridgeon.app.global.exception.error;
+
+import com.bridgeon.app.global.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum BusinessPlanErrorCode implements ErrorCode {
+
+    // 400
+    INVALID_TITLE(HttpStatus.BAD_REQUEST.value(), "B4001", "제목이 유효하지 않습니다."),
+    INVALID_CONTENT(HttpStatus.BAD_REQUEST.value(), "B4002", "사업계획서 내용이 유효하지 않습니다."),
+    FILE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST.value(), "B4003", "파일 업로드에 실패했습니다."),
+
+    // 401
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "B4011", "인증되지 않은 사용자입니다."),
+
+    // 403
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), "B4031", "해당 사업계획서를 열람할 권한이 없습니다."),
+
+    // 404
+    BUSINESS_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "B4041", "사업계획서를 찾을 수 없습니다."),
+
+    // 500
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "B5001", "사업계획서 처리 중 서버 오류가 발생했습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}
+


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#37 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### BusinessPlanController
- GET /api/v1/business-plans/my => 로그인 사용자 기준 내 사업계획서 목록 조회
- GET /api/v1/business-plans/{businessPlanId} => 상세 조회

### BusinessPlanServiceImpl (implements BusinessPlanUseCase)
- 작성자 본인이면 바로 상세 응답
- 작성자가 아니면 employ_applications에 APPROVED 존재 여부 확인 => APPROVED 시 열람 가능

### EmployBoardEntity
- 사업계획서 참조 매핑 추가


### 테스트
#### 지원 목록 불러오기 성공
<img width="2290" height="1652" alt="image" src="https://github.com/user-attachments/assets/3e54c54a-0555-4db2-a045-b5930b6d00b7" />

#### 지원 상세 조회 성공 , 아이디 13토큰이 자신의 사업계획서 조회
<img width="1800" height="1096" alt="image" src="https://github.com/user-attachments/assets/4eb1fb94-9e1b-4c78-9076-e10b06d34919" />

#### 지원 상세 조회 성공, 아이디 15 토큰이 열람승인난 사업계획서 조회
<img width="1564" height="1052" alt="image" src="https://github.com/user-attachments/assets/740161ce-bc75-4824-ba44-930bdfb8f94d" />

#### 지원 상세 조회 실패, 아이디 15토큰이 열람승인나지않은 사업계획서 조회
<img width="1374" height="720" alt="image" src="https://github.com/user-attachments/assets/967cedb6-c8e9-4d63-96cd-39f0a306eb20" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.