### PR TITLE
[ Feature # 40 ] 구인게시판 비즈니스 계획서 연결

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
@@ -19,9 +19,11 @@ public record EmployPostItemResponseDto(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime deletedAt,
-        boolean isScraped
+        boolean authorized,
+        boolean isScraped,
+        Long businessPlanId
 ) {
-    public static EmployPostItemResponseDto of(EmployBoard e, boolean isScraped) {
+    public static EmployPostItemResponseDto of(EmployBoard e,boolean authorized, boolean isScraped) {
         return new EmployPostItemResponseDto(
                 e.getId(),
                 e.getUser() != null ? e.getUser().getId() : null, // 인증 구현되면 수정 예정
@@ -34,7 +36,9 @@ public record EmployPostItemResponseDto(
                 e.getCreatedAt(),
                 e.getUpdatedAt(),
                 e.getDeletedAt(),
-                isScraped
+                authorized,
+                isScraped,
+                (e.getBusinessPlan() != null ? e.getBusinessPlan().getId() : null)
         );
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/repository/ReadAuthorizationJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/board/repository/ReadAuthorizationJpaRepository.java
@@ -1,0 +1,14 @@
+package com.bridgeon.app.domain.board.repository;
+
+import com.bridgeon.app.domain.user.entity.ReadAuthorization;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ReadAuthorizationJpaRepository extends JpaRepository<ReadAuthorization, Long> {
+
+    // 승인 여부체크
+    boolean existsByBusinessPlan_IdAndUser_IdAndIsAcceptedTrue(Long businessPlanId, Long userId);
+
+}

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
@@ -5,10 +5,12 @@ import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
 import com.bridgeon.app.domain.board.entity.EmployBoard;
 import com.bridgeon.app.domain.board.repository.EmployBoardJpaRepository;
 import com.bridgeon.app.domain.board.repository.EmployScrapJpaRepository;
+import com.bridgeon.app.domain.board.usecase.CheckReadPermissionUseCase;
 import com.bridgeon.app.global.exception.custom.BusinessException;
 import com.bridgeon.app.global.exception.error.EmployErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -17,15 +19,29 @@ public class EmployDetailService {
 
     private final EmployBoardJpaRepository employBoardJpaRepository;
     private final EmployScrapJpaRepository employScrapJpaRepository;
+    private final CheckReadPermissionUseCase checkReadPermissionUseCase;
 
-    public EmployPostItemResponseDto getDetail(Long employBoardId, Long userId) {
-        EmployBoard board = employBoardJpaRepository.findByIdAndDeletedAtIsNull(employBoardId)
+    @Transactional(readOnly = true)
+    public EmployPostItemResponseDto getDetail(Long employBoardId, Long currentUserId) {
+        EmployBoard board = employBoardJpaRepository.findById(employBoardId)
                 .orElseThrow(() -> new BusinessException(EmployErrorCode.EMPLOY_BOARD_NOT_FOUND));
 
+        boolean isOwner = currentUserId != null && board.getUser().getId().equals(currentUserId);
 
-        boolean isScraped = employScrapJpaRepository.existsByUserIdAndEmployBoardId(userId, board.getId());
+        Long businessPlanId = (board.getBusinessPlan() != null)
+                ? board.getBusinessPlan().getId()
+                : null;
+
+        boolean authorized = isOwner
+                || (currentUserId != null
+                && businessPlanId != null
+                && checkReadPermissionUseCase.canReadBusinessPlan(businessPlanId, currentUserId));
+
+        boolean isScraped = currentUserId != null
+                && employScrapJpaRepository.existsByUserIdAndEmployBoardId(currentUserId, board.getId());
 
 
-        return EmployPostItemResponseDto.of(board, false);
+
+        return EmployPostItemResponseDto.of(board, authorized, isScraped);
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployPostService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployPostService.java
@@ -72,10 +72,13 @@ public class EmployPostService {
         Page<EmployBoard> boards = employBoardJpaRepository.findAll(example, ensured);
 
         // DTO 매핑
-        return boards.map(e -> EmployPostItemResponseDto.of(
-                e,
-                currentUserId != null &&
-                        employScrapJpaRepository.existsByUserIdAndEmployBoardId(currentUserId, e.getId())
-        ));
+        return boards.map(e -> {
+            boolean isScraped = currentUserId != null &&
+                    employScrapJpaRepository.existsByUserIdAndEmployBoardId(currentUserId, e.getId());
+
+            boolean authorized = false; // 목록 조회에서는 열람 승인 여부 의미 없음(상세에서 체크)
+
+            return EmployPostItemResponseDto.of(e, authorized, isScraped);
+        });
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/ReadAuthorizationService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/ReadAuthorizationService.java
@@ -1,0 +1,20 @@
+package com.bridgeon.app.domain.board.service;
+
+import com.bridgeon.app.domain.board.repository.ReadAuthorizationJpaRepository;
+import com.bridgeon.app.domain.board.usecase.CheckReadPermissionUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class ReadAuthorizationService implements CheckReadPermissionUseCase {
+
+    private final ReadAuthorizationJpaRepository readAuthorizationJpaRepository;
+
+    @Override
+    public boolean canReadBusinessPlan(Long businessPlanId, Long currentUserId) {
+        return readAuthorizationJpaRepository
+                .existsByBusinessPlan_IdAndUser_IdAndIsAcceptedTrue(businessPlanId, currentUserId);
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/board/usecase/CheckReadPermissionUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/board/usecase/CheckReadPermissionUseCase.java
@@ -1,0 +1,5 @@
+package com.bridgeon.app.domain.board.usecase;
+
+public interface CheckReadPermissionUseCase {
+    boolean canReadBusinessPlan(Long businessPlanId, Long currentUserId);;
+}

--- a/src/main/java/com/bridgeon/app/domain/board/usecase/ReadAuthorizationUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/board/usecase/ReadAuthorizationUseCase.java
@@ -1,0 +1,8 @@
+package com.bridgeon.app.domain.board.usecase;
+
+public interface ReadAuthorizationUseCase {
+    Long apply(Long employBoardId, Long requesterId);
+    void approve(Long employBoardId, Long readAuthId, Long ownerId);
+    void reject(Long employBoardId, Long readAuthId, Long ownerId);
+    void cancel(Long employBoardId, Long readAuthId, Long requesterId);
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/BusinessPlanDetailResponseDto.java
@@ -14,11 +14,12 @@ public record BusinessPlanDetailResponseDto(
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-    public static BusinessPlanListResponseDto of(BusinessPlan bp) {
-        return new BusinessPlanListResponseDto(
+    public static BusinessPlanDetailResponseDto of(BusinessPlan bp) {
+        return new BusinessPlanDetailResponseDto(
                 bp.getId(),
                 bp.getTitle(),
                 bp.getBusinessType(),
+                bp.getContent(),
                 bp.getCreatedAt(),
                 bp.getUpdatedAt()
         );


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#40 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### EmployPostItemResponseDto 수정
- authorized 필드 추가 → 열람 승인 여부 내려줌
- businessPlanId 필드 추가 → 사업계획서 상세 조회 API와 연동 가능

### EmployDetailService 수정
- CheckReadPermissionUseCase 통해 승인 여부 확인 후 authorized 결정
- businessPlanId 함께 내려주도록 처리

### 테스트  , "authorized": true
<img width="2094" height="1134" alt="image" src="https://github.com/user-attachments/assets/08536183-bf00-4a37-ae8e-64fcaf6b1944" />

### 테스트, "authorized": false
<img width="1506" height="1094" alt="image" src="https://github.com/user-attachments/assets/15739e79-f3e4-4fef-b4e1-41b4843ad89a" />


## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.