### PR TITLE
[ Feature #19 ] 게시판- 첨부파일 / 프로필 - 첨부파일 연동

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/attachment/dto/response/AttachmentResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/attachment/dto/response/AttachmentResponseDto.java
@@ -1,0 +1,40 @@
+package com.bridgeon.app.domain.attachment.dto.response;
+
+import com.bridgeon.app.domain.attachment.entity.Attachment;
+import com.bridgeon.app.global.enums.attachment.MimeType;
+import com.bridgeon.app.global.enums.attachment.TargetType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AttachmentResponseDto(
+        Long attachmentsId,
+        String fileUrl,
+        MimeType mimeType,
+        TargetType targetType,
+        Long targetId,
+        Integer sortOrder,
+        LocalDateTime createdAt
+) {
+    public static AttachmentResponseDto of(Attachment entity) {
+        return new AttachmentResponseDto(
+                entity.getId(),
+                entity.getFileUrl(),
+                entity.getMimeType(),
+                entity.getTargetType(),
+                entity.getTargetId(),
+                entity.getSortOrder(),
+                entity.getCreatedAt()
+        );
+    }
+
+    public static List<AttachmentResponseDto> ofList(List<Attachment> attachments) {
+        if (attachments == null || attachments.isEmpty()) {
+            return List.of();
+        }
+        return attachments.stream()
+                .map(AttachmentResponseDto::of)
+
+                .toList();
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/attachment/entity/Attachment.java
+++ b/src/main/java/com/bridgeon/app/domain/attachment/entity/Attachment.java
@@ -36,7 +36,7 @@ public class Attachment {
     private Long targetId; // 연결된 대상 PK 값
 
     @Column(name = "sort_order", nullable = false)
-    private Integer saveOrder;  // 저장 순서(기본 0)
+    private Integer sortOrder = 0;  // 저장 순서(기본 0)
 
     @CreatedDate
     @Column(name = "created_at", nullable = false)

--- a/src/main/java/com/bridgeon/app/domain/attachment/repository/AttachmentJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/attachment/repository/AttachmentJpaRepository.java
@@ -1,0 +1,25 @@
+package com.bridgeon.app.domain.attachment.repository;
+
+import com.bridgeon.app.domain.attachment.entity.Attachment;
+import com.bridgeon.app.global.enums.attachment.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AttachmentJpaRepository extends JpaRepository<Attachment, Long> {
+
+    // 대상별 첨부파일 목록 (정렬 순서 오름차순) → 자유/구인/포트폴리오/사업계획서
+    List<Attachment> findByTargetTypeAndTargetIdOrderBySortOrderAsc(TargetType targetType, Long targetId);
+
+    // 대표 이미지 단건 조회 (sortOrder 가장 작은 파일) → 프로필
+    Optional<Attachment> findFirstByTargetTypeAndTargetIdOrderBySortOrderAsc(TargetType targetType, Long targetId);
+
+    // 대상별 전체 삭제 (치환/재업로드 시 사용)
+    void deleteByTargetTypeAndTargetId(TargetType targetType, Long targetId);
+
+    // 대상 존재 여부 확인
+    boolean existsByTargetTypeAndTargetId(TargetType targetType, Long targetId);
+}

--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/EmployPostItemResponseDto.java
@@ -1,11 +1,13 @@
 package com.bridgeon.app.domain.board.dto.response;
 
+import com.bridgeon.app.domain.attachment.dto.response.AttachmentResponseDto;
 import com.bridgeon.app.domain.board.entity.EmployBoard;
 import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.global.enums.user.InterestField;
 import com.bridgeon.app.global.enums.user.Region;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record EmployPostItemResponseDto(
         Long employBoardId,
@@ -21,9 +23,10 @@ public record EmployPostItemResponseDto(
         LocalDateTime deletedAt,
         boolean authorized,
         boolean isScraped,
-        Long businessPlanId
+        Long businessPlanId,
+        List<AttachmentResponseDto> attachments
 ) {
-    public static EmployPostItemResponseDto of(EmployBoard e,boolean authorized, boolean isScraped) {
+    public static EmployPostItemResponseDto of(EmployBoard e,boolean authorized, boolean isScraped,List<AttachmentResponseDto> attachments) {
         return new EmployPostItemResponseDto(
                 e.getId(),
                 e.getUser() != null ? e.getUser().getId() : null, // 인증 구현되면 수정 예정
@@ -38,7 +41,13 @@ public record EmployPostItemResponseDto(
                 e.getDeletedAt(),
                 authorized,
                 isScraped,
-                (e.getBusinessPlan() != null ? e.getBusinessPlan().getId() : null)
+                (e.getBusinessPlan() != null ? e.getBusinessPlan().getId() : null),
+                attachments
         );
+    }
+    public static EmployPostItemResponseDto of(
+            EmployBoard e, boolean authorized, boolean isScraped
+    ) {
+        return of(e, authorized, isScraped, List.of());
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/dto/response/FreeDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/board/dto/response/FreeDetailResponseDto.java
@@ -1,9 +1,11 @@
 package com.bridgeon.app.domain.board.dto.response;
 
+import com.bridgeon.app.domain.attachment.dto.response.AttachmentResponseDto;
 import com.bridgeon.app.domain.board.entity.FreeBoard;
 import com.bridgeon.app.domain.user.entity.User;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record FreeDetailResponseDto(
         Long freeBoardId,
@@ -12,9 +14,10 @@ public record FreeDetailResponseDto(
         String freeBoardContent,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        LocalDateTime deletedAt
+        LocalDateTime deletedAt,
+        List<AttachmentResponseDto> attachments
 ) {
-    public static FreeDetailResponseDto from(FreeBoard f) {
+    public static FreeDetailResponseDto from(FreeBoard f, List<AttachmentResponseDto> attachments) {
         return new FreeDetailResponseDto(
                 f.getId(),
                 f.getUser() != null ? f.getUser().getId() : null, //추후에 인증 구현되면 수정 예정
@@ -22,7 +25,8 @@ public record FreeDetailResponseDto(
                 f.getFreeBoardContent(),
                 f.getCreatedAt(),
                 f.getUpdatedAt(),
-                f.getDeletedAt()
+                f.getDeletedAt(),
+                attachments
         );
 
     }

--- a/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/EmployDetailService.java
@@ -1,16 +1,21 @@
 package com.bridgeon.app.domain.board.service;
 
 
+import com.bridgeon.app.domain.attachment.dto.response.AttachmentResponseDto;
+import com.bridgeon.app.domain.attachment.repository.AttachmentJpaRepository;
 import com.bridgeon.app.domain.board.dto.response.EmployPostItemResponseDto;
 import com.bridgeon.app.domain.board.entity.EmployBoard;
 import com.bridgeon.app.domain.board.repository.EmployBoardJpaRepository;
 import com.bridgeon.app.domain.board.repository.EmployScrapJpaRepository;
 import com.bridgeon.app.domain.board.usecase.CheckReadPermissionUseCase;
+import com.bridgeon.app.global.enums.attachment.TargetType;
 import com.bridgeon.app.global.exception.custom.BusinessException;
 import com.bridgeon.app.global.exception.error.EmployErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -20,6 +25,7 @@ public class EmployDetailService {
     private final EmployBoardJpaRepository employBoardJpaRepository;
     private final EmployScrapJpaRepository employScrapJpaRepository;
     private final CheckReadPermissionUseCase checkReadPermissionUseCase;
+    private final AttachmentJpaRepository attachmentJpaRepository;
 
     @Transactional(readOnly = true)
     public EmployPostItemResponseDto getDetail(Long employBoardId, Long currentUserId) {
@@ -40,8 +46,12 @@ public class EmployDetailService {
         boolean isScraped = currentUserId != null
                 && employScrapJpaRepository.existsByUserIdAndEmployBoardId(currentUserId, board.getId());
 
+        List<AttachmentResponseDto> attachments = AttachmentResponseDto.ofList(
+                attachmentJpaRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(
+                        TargetType.EMPLOY_BOARD, employBoardId
+                )
+        );
 
-
-        return EmployPostItemResponseDto.of(board, authorized, isScraped);
+        return EmployPostItemResponseDto.of(board, authorized, isScraped, attachments);
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/board/service/FreeDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/board/service/FreeDetailService.java
@@ -1,21 +1,28 @@
 package com.bridgeon.app.domain.board.service;
 
 
+import com.bridgeon.app.domain.attachment.dto.response.AttachmentResponseDto;
+import com.bridgeon.app.domain.attachment.repository.AttachmentJpaRepository;
 import com.bridgeon.app.domain.board.dto.response.FreeDetailResponseDto;
 import com.bridgeon.app.domain.board.entity.FreeBoard;
 import com.bridgeon.app.domain.board.repository.FreeBoardJpaRepository;
 import com.bridgeon.app.domain.board.usecase.GetFreeDetailUseCase;
+import com.bridgeon.app.global.enums.attachment.TargetType;
 import com.bridgeon.app.global.exception.custom.BusinessException;
 import com.bridgeon.app.global.exception.error.FreeErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FreeDetailService implements GetFreeDetailUseCase {
 
     private final FreeBoardJpaRepository freeBoardRepository;
+    private final AttachmentJpaRepository attachmentRepository;
+
 
     @Transactional(readOnly = true)
     @Override
@@ -23,6 +30,12 @@ public class FreeDetailService implements GetFreeDetailUseCase {
         FreeBoard freeBoard = freeBoardRepository.findByIdAndDeletedAtIsNull(freeBoardId)
                 .orElseThrow(() -> new BusinessException(FreeErrorCode.FREE_BOARD_NOT_FOUND));
 
-        return FreeDetailResponseDto.from(freeBoard);
+        List<AttachmentResponseDto> attachments = AttachmentResponseDto.ofList(
+                attachmentRepository.findByTargetTypeAndTargetIdOrderBySortOrderAsc(
+                        TargetType.FREE_BOARD, freeBoardId
+                )
+        );
+
+        return FreeDetailResponseDto.from(freeBoard,attachments);
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantProfileResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/ApplicantProfileResponseDto.java
@@ -12,9 +12,10 @@ public record ApplicantProfileResponseDto(
         String region,
         String interestField,
         String introduction,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String profileImageUrl
 ) {
-    public static ApplicantProfileResponseDto of(User u) {
+    public static ApplicantProfileResponseDto of(User u, String profileImageUrl) {
         return new ApplicantProfileResponseDto(
                 u.getId(),
                 u.getName(),
@@ -23,7 +24,8 @@ public record ApplicantProfileResponseDto(
                 u.getRegion().name(),
                 u.getInterestField().name(),
                 u.getIntroduction(),
-                u.getCreatedAt()
+                u.getCreatedAt(),
+                profileImageUrl
         );
     }
 }

--- a/src/main/java/com/bridgeon/app/domain/user/service/ApplicantDetailService.java
+++ b/src/main/java/com/bridgeon/app/domain/user/service/ApplicantDetailService.java
@@ -1,5 +1,7 @@
 package com.bridgeon.app.domain.user.service;
 
+import com.bridgeon.app.domain.attachment.entity.Attachment;
+import com.bridgeon.app.domain.attachment.repository.AttachmentJpaRepository;
 import com.bridgeon.app.domain.user.dto.response.ApplicantDetailResponseDto;
 import com.bridgeon.app.domain.user.dto.response.ApplicantProfileResponseDto;
 import com.bridgeon.app.domain.user.dto.response.PortfolioDetailItemResponseDto;
@@ -8,6 +10,7 @@ import com.bridgeon.app.domain.user.entity.User;
 import com.bridgeon.app.domain.user.repository.PortfolioJpaRepository;
 import com.bridgeon.app.domain.user.repository.UserRepository;
 import com.bridgeon.app.domain.user.usecase.GetApplicantDetailUseCase;
+import com.bridgeon.app.global.enums.attachment.TargetType;
 import com.bridgeon.app.global.enums.portfolio.Visibility;
 import com.bridgeon.app.global.exception.custom.BusinessException;
 import com.bridgeon.app.global.exception.error.AuthErrorCode;
@@ -24,6 +27,7 @@ public class ApplicantDetailService implements GetApplicantDetailUseCase {
 
     private final UserRepository userRepository;
     private final PortfolioJpaRepository portfolioJpaRepository;
+    private final AttachmentJpaRepository attachmentJpaRepository;
 
     @Override
     public ApplicantDetailResponseDto excute(Long applicantUserId, Long currentUserId) {
@@ -42,7 +46,13 @@ public class ApplicantDetailService implements GetApplicantDetailUseCase {
                 .map(PortfolioDetailItemResponseDto::of)
                 .toList();
 
-        ApplicantProfileResponseDto applicantProfileResponseDto = ApplicantProfileResponseDto.of(applicant);
+        String profileUrl = attachmentJpaRepository
+                .findFirstByTargetTypeAndTargetIdOrderBySortOrderAsc(TargetType.USER, applicantUserId)
+                .map(Attachment::getFileUrl)
+                .orElse(null);
+
+        // ApplicantProfileResponseDto에 프로필 이미지 포함
+        ApplicantProfileResponseDto applicantProfileResponseDto = ApplicantProfileResponseDto.of(applicant, profileUrl);
 
         return new ApplicantDetailResponseDto(applicantProfileResponseDto, portfolioDto);
 


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#19 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

### AttachmentResponseDto
- ofList(List<Attachment>) 정적 메서드 추가하여 엔티티 리스트 → DTO 리스트 변환 지원

### EmployPostItemResponseDto
- attachments 필드 추가 (List<AttachmentResponseDto>)
- (EmployBoard, boolean, boolean, List<AttachmentResponseDto>) : 상세 조회용
- (EmployBoard, boolean, boolean) : 기존 목록 조회 호환

### FreeDetailResponseDto
- attachments 필드 추가하여 자유게시판 상세 조회 시 첨부파일 포함 가능하도록 수정

### EmployDetailService
- 구인 상세 조회 시 attachments 조회 및 매핑 로직 추가
- AttachmentJpaRepository 활용, TargetType.EMPLOY_BOARD 기준으로 첨부파일 리스트 조회 후 DTO 변환

### FreeDetailService
- 자유 상세 조회 시 attachments 조회 및 매핑 로직 추가
- TargetType.FREE_BOARD 기준으로 첨부파일 리스트 조회

### ApplicantDetailService
- 프로필 조회 시 TargetType.USER 기준 대표 첨부파일(프로필 이미지) 1건 조회
- ApplicantProfileResponseDto에 profileImageUrl 필드 추가 및 함께 반환


### 테스트

#### 지원자 상세 목록 조회 성공
<img width="1576" height="1316" alt="image" src="https://github.com/user-attachments/assets/6b9aab5a-069d-4680-8ebd-3d152cf41a53" />

#### 구인게시판, 자유게시판 성공
<img width="2600" height="1216" alt="image" src="https://github.com/user-attachments/assets/79cc9553-29ec-4a52-a320-6922e5cfeb7b" />

<img width="1362" height="1032" alt="image" src="https://github.com/user-attachments/assets/3b4f8c93-1873-4cef-9848-56b20380eb3c" />





## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.