### PR TITLE
[Feature #65] 사용자 정보 관련 API 작성

### DIFF
--- a/src/main/java/com/bridgeon/app/domain/user/controller/PortfolioController.java
+++ b/src/main/java/com/bridgeon/app/domain/user/controller/PortfolioController.java
@@ -1,0 +1,60 @@
+package com.bridgeon.app.domain.user.controller;
+
+import com.bridgeon.app.domain.user.dto.response.PortfolioDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.PortfolioListResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.usecase.PortfolioUseCase;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/portfolios")
+@RequiredArgsConstructor
+public class PortfolioController {
+
+    private final PortfolioUseCase portfolioUseCase;
+
+    @GetMapping("/my")
+    public ResponseDto<PortfolioListResponseDto> getMyPortfolios(
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        PortfolioListResponseDto data = portfolioUseCase.getListByUserId(user.getId());
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "내 포트폴리오 목록 조회 성공",
+                data
+        );
+    }
+
+    @GetMapping("/{portfolioId}")
+    public ResponseDto<PortfolioDetailResponseDto> getPortfolioDetail(
+        @AuthenticationPrincipal User user,
+        @PathVariable Long portfolioId
+    ) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        PortfolioDetailResponseDto data = portfolioUseCase.getDetail(user, portfolioId);
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "포트폴리오 상세 조회 성공",
+                data
+        );
+    }
+
+}

--- a/src/main/java/com/bridgeon/app/domain/user/controller/UserController.java
+++ b/src/main/java/com/bridgeon/app/domain/user/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.bridgeon.app.domain.user.controller;
+
+import com.bridgeon.app.domain.user.dto.response.MyPageResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.usecase.UserUseCase;
+import com.bridgeon.app.global.dto.response.ResponseDto;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserUseCase userUseCase;
+
+    @GetMapping("/me")
+    public ResponseDto<MyPageResponseDto> getUserInfo(
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        MyPageResponseDto data = userUseCase.getUserInfo(user.getId());
+
+        return ResponseDto.success(
+                HttpStatus.OK,
+                "마이페이지 조회 성공",
+                data
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/MyPageResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/MyPageResponseDto.java
@@ -1,0 +1,19 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.global.enums.user.InterestField;
+import com.bridgeon.app.global.enums.user.Provider;
+import com.bridgeon.app.global.enums.user.Region;
+import com.bridgeon.app.global.enums.user.Role;
+
+public record MyPageResponseDto(
+    Long id,
+    Provider provider,
+    Role role,
+    String email,
+    String name,
+    String nickname,
+    Region region,
+    InterestField interestField,
+    String introduction
+) {
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioDetailResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioDetailResponseDto.java
@@ -1,0 +1,14 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import com.bridgeon.app.global.enums.portfolio.Visibility;
+
+import java.time.LocalDateTime;
+
+public record PortfolioDetailResponseDto(
+        String title,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String introduction,
+        Visibility visibility
+) {
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioItemDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioItemDto.java
@@ -1,0 +1,11 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import java.time.LocalDateTime;
+
+public record PortfolioItemDto(
+        Long id,
+        String title,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioListResponseDto.java
+++ b/src/main/java/com/bridgeon/app/domain/user/dto/response/PortfolioListResponseDto.java
@@ -1,0 +1,8 @@
+package com.bridgeon.app.domain.user.dto.response;
+
+import java.util.List;
+
+public record PortfolioListResponseDto(
+        List<PortfolioItemDto> portfolios
+) {
+}

--- a/src/main/java/com/bridgeon/app/domain/user/entity/Portfolio.java
+++ b/src/main/java/com/bridgeon/app/domain/user/entity/Portfolio.java
@@ -28,8 +28,8 @@ public class Portfolio extends BaseEntity {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "visibility", nullable = false)
-    private Visibility visibility; // 공개 여부
+    @Column(name = "visibility", nullable = false, length = 16)
+    private Visibility visibility;
 
     @Column(name = "title", nullable = false)
     private String title; // 프로젝트 제목

--- a/src/main/java/com/bridgeon/app/domain/user/repository/PortfolioJpaRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/user/repository/PortfolioJpaRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface PortfolioJpaRepository extends JpaRepository<Portfolio, Long> {
         List<Portfolio> findByUser_IdOrderByCreatedAtDesc(Long userId);
         List<Portfolio> findByUser_IdAndVisibilityOrderByCreatedAtDesc(Long userId, Visibility visibility);
+
+        List<Portfolio> findAllByUser_IdOrderByStartDateDesc(Long userId);
 }

--- a/src/main/java/com/bridgeon/app/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/bridgeon/app/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/com/bridgeon/app/domain/user/service/PortfolioService.java
+++ b/src/main/java/com/bridgeon/app/domain/user/service/PortfolioService.java
@@ -1,0 +1,62 @@
+package com.bridgeon.app.domain.user.service;
+
+import com.bridgeon.app.domain.user.dto.response.PortfolioDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.PortfolioItemDto;
+import com.bridgeon.app.domain.user.dto.response.PortfolioListResponseDto;
+import com.bridgeon.app.domain.user.entity.Portfolio;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.repository.PortfolioJpaRepository;
+import com.bridgeon.app.domain.user.usecase.PortfolioUseCase;
+import com.bridgeon.app.global.enums.portfolio.Visibility;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PortfolioService implements PortfolioUseCase {
+
+    private final PortfolioJpaRepository portfolioRepository;
+
+    @Override
+    public PortfolioListResponseDto getListByUserId(Long userId) {
+        List<Portfolio> portfolios = portfolioRepository.findAllByUser_IdOrderByStartDateDesc(userId);
+
+        List<PortfolioItemDto> items = portfolios.stream()
+                .map(p -> new PortfolioItemDto(
+                        p.getId(),
+                        p.getTitle(),
+                        p.getStartDate(),
+                        p.getEndDate()
+                ))
+                .toList();
+
+        return new PortfolioListResponseDto(items);
+    }
+
+
+    @Override
+    public PortfolioDetailResponseDto getDetail(User viewer, Long portfolioId) {
+        Portfolio p = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.UNAUTHORIZED));
+
+        // PRIVATE이면 소유자만 접근 가능
+        if (p.getVisibility() == Visibility.PRIVATE &&
+                !p.getUser().getId().equals(viewer.getId())) {
+            throw new BusinessException(AuthErrorCode.ACCESS_DENIED);
+        }
+
+        return new PortfolioDetailResponseDto(
+                p.getTitle(),
+                p.getStartDate(),
+                p.getEndDate(),
+                p.getIntroduction(),
+                p.getVisibility()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/service/UserService.java
+++ b/src/main/java/com/bridgeon/app/domain/user/service/UserService.java
@@ -1,0 +1,37 @@
+package com.bridgeon.app.domain.user.service;
+
+import com.bridgeon.app.domain.user.dto.response.MyPageResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+import com.bridgeon.app.domain.user.repository.UserRepository;
+import com.bridgeon.app.domain.user.usecase.UserUseCase;
+import com.bridgeon.app.global.exception.custom.BusinessException;
+import com.bridgeon.app.global.exception.error.AuthErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService implements UserUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public MyPageResponseDto getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+        return new MyPageResponseDto(
+                user.getId(),
+                user.getProvider(),
+                user.getRole(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getRegion(),
+                user.getInterestField(),
+                user.getIntroduction()
+        );
+    }
+}

--- a/src/main/java/com/bridgeon/app/domain/user/usecase/PortfolioUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/user/usecase/PortfolioUseCase.java
@@ -1,0 +1,10 @@
+package com.bridgeon.app.domain.user.usecase;
+
+import com.bridgeon.app.domain.user.dto.response.PortfolioDetailResponseDto;
+import com.bridgeon.app.domain.user.dto.response.PortfolioListResponseDto;
+import com.bridgeon.app.domain.user.entity.User;
+
+public interface PortfolioUseCase {
+    PortfolioListResponseDto getListByUserId(Long userId);
+    PortfolioDetailResponseDto getDetail(User viewer, Long portfolioId);
+}

--- a/src/main/java/com/bridgeon/app/domain/user/usecase/UserUseCase.java
+++ b/src/main/java/com/bridgeon/app/domain/user/usecase/UserUseCase.java
@@ -1,0 +1,8 @@
+package com.bridgeon.app.domain.user.usecase;
+
+import com.bridgeon.app.domain.user.dto.response.MyPageResponseDto;
+
+public interface UserUseCase {
+
+    MyPageResponseDto getUserInfo(Long userId);
+}

--- a/src/main/java/com/bridgeon/app/global/exception/error/AuthErrorCode.java
+++ b/src/main/java/com/bridgeon/app/global/exception/error/AuthErrorCode.java
@@ -27,8 +27,7 @@ public enum AuthErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "A4041", "사용자를 찾을 수 없습니다."),
 
     // 503
-    DENIED_KAKAO_TOKEN(HttpStatus.SERVICE_UNAVAILABLE.value(), "A5031", "카카오 토큰 발급 실패"),
-    DENIED_KAKAO_USER(HttpStatus.SERVICE_UNAVAILABLE.value(), "A5032", "카카오 사용자 조회 실패");
+    DENIED_KAKAO_TOKEN(HttpStatus.SERVICE_UNAVAILABLE.value(), "A5031", "카카오 토큰 발급 실패");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/com/bridgeon/app/global/oauth2/kakao/client/KakaoOAuthClient.java
+++ b/src/main/java/com/bridgeon/app/global/oauth2/kakao/client/KakaoOAuthClient.java
@@ -76,6 +76,6 @@ public class KakaoOAuthClient {
             return body;
         }
 
-        throw new BusinessException(AuthErrorCode.DENIED_KAKAO_USER);
+        throw new BusinessException(AuthErrorCode.DENIED_KAKAO_TOKEN);
     }
 }

--- a/src/test/java/com/bridgeon/app/auth/AuthTest.java
+++ b/src/test/java/com/bridgeon/app/auth/AuthTest.java
@@ -61,7 +61,7 @@ public class AuthTest extends BaseTest {
 
     @Test
     void 기존_사용자_토큰발급() {
-        Long userId = 13L; // id 수정해서 사용
+        Long userId = 1L; // id 수정해서 사용
 
         User existing = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
## 📌 Related Issue
> #이슈번호

#65 

## 🚀 Description
> 작업 내용에 대해 간단하게 설명해주세요. (스크린샷 포함)

1. 포트폴리오 목록 조회 API 작성
<img width="1280" height="1252" alt="image" src="https://github.com/user-attachments/assets/74bc899c-870a-467f-af42-7efc4c1df1d7" />
2. 포트폴리오 상세 조회 API 작성
비공개 포트폴리오 접근 시 403 띄우기
<img width="1274" height="996" alt="image" src="https://github.com/user-attachments/assets/fe843087-0308-426a-b21c-5ce912d92918" />
3. 마이페이지 (사용자 정보) 조회 API 작성
<img width="1276" height="1282" alt="image" src="https://github.com/user-attachments/assets/5cdc112b-e62d-40a8-aeff-c7ecf60318da" />



## 📢 Notes
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.